### PR TITLE
STAMPED incorporation into paper

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -105,6 +105,7 @@ T.2  & Tracked        & All components SHOULD be tracked using the same content-
 T.3  & Tracked        & Provenance of all modifications MUST be recorded \\
 T.4  & Tracked        & Code-driven provenance SHOULD be recorded programmatically and MUST include the versions of all components involved \\
 A.1  & Actionable     & Research object MUST contain sufficient instructions to reproduce all computational results \\
+A.2  & Actionable     & Procedures SHOULD be specified as executable specifications \\
 M.1  & Modular        & Components SHOULD be organized in a modular structure \\
 M.2  & Modular        & Components MAY be included directly or linked as subdatasets \\
 P.1  & Portable       & Procedures MUST NOT depend on undocumented host environment state \\


### PR DESCRIPTION
In this PR I have a first implementation of the stamped-acronym proposal.

- The rules are very close to the proposal with some additions:
  - T.3 (provenance recording) and T.4 (programmatic provenance) — folded from old Provenance pillar into Tracked
  - D.1 rewritten: "All referenced modules and components MUST be persistently retrievable by others" (replaces old environment rules which moved to P)
  - Old D.1/D.3 (environment specification and version control) moved to P.1–P.3 where they belong
  - Old D.4 (environment self-containment) dropped for now
- Introduction is revised to use WCI-FW workflow definition (cited, not our own)
- Introduction identifies the current state, the gap (FAIR doesn't cover operational reproducibility properties), and then flows into what we introduce
- New Results sections for S, A, E, D with prose — T, M, P have remapped existing prose
- Each property framed as a spectrum from practical minimums to aspirational ideals
- YODA → STAMPED pass throughout Discussion and Related Work
- Term hierarchy (Research Object > Module > Component) used consistently, replacing "asset" terminology

**Still rough / needs discussion:**
- D rules need further refinement (#38)
- Discussion still has subheadings (NMETH violation)
- P vs D boundary — where does "reproducible builds" live?
- Actionability MUST-level wording (#31)
- TODOs scattered throughout marking open questions
- Recycle bin section at end of intro has removed text that may be useful elsewhere