### PR TITLE
WIP: gather-context skill for reading GitHub discussion history

### DIFF
--- a/.claude/scripts/gh-pr-comments
+++ b/.claude/scripts/gh-pr-comments
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Fetch inline review comments from a GitHub PR (read-only).
+# Usage: gh-pr-comments <PR-URL>
+#        gh-pr-comments <owner/repo> <number>
+set -eu
+
+if [[ "${1:-}" =~ github\.com/([^/]+)/([^/]+)/pull[s]?/([0-9]+) ]]; then
+    owner="${BASH_REMATCH[1]}"
+    repo="${BASH_REMATCH[2]}"
+    number="${BASH_REMATCH[3]}"
+elif [[ $# -eq 2 ]]; then
+    IFS='/' read -r owner repo <<< "$1"
+    number="$2"
+else
+    echo "Usage: $0 <PR-URL> or $0 <owner/repo> <number>" >&2
+    exit 1
+fi
+
+gh api --paginate "repos/${owner}/${repo}/pulls/${number}/comments" \
+  --jq '.[] | "## \(.path):\(.line // .original_line)\n\(.user.login) (\(.created_at[:10]))\n\n\(.body)\n\n---"'

--- a/.claude/skills/gather-context/SKILL.md
+++ b/.claude/skills/gather-context/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: gather-context
+description: Search GitHub issues and PRs for discussion related to the current task. Use when starting work on a topic to find relevant project history.
+argument-hint: "[search terms | github-url] [--limit N]"
+context: fork
+---
+
+You are a research agent. Search this project's GitHub issues and PR discussions for context relevant to the current task. Fetch generously — read everything that might be relevant — but return only a curated summary.
+
+## Parse arguments
+
+Parse $ARGUMENTS for:
+- An optional `--limit N` flag (default: 5) controlling how many search results to fetch
+- A GitHub issue/PR URL (e.g. `https://github.com/myyoda/principles-paper/issues/36`)
+- Or plain search terms
+
+Examples:
+- `STAMPED --limit 3` → terms="STAMPED", limit=3
+- `STAMPED` → terms="STAMPED", limit=5
+- `https://github.com/myyoda/principles-paper/issues/36` → seed from that issue
+- `--limit 10` → no explicit terms (infer them), limit=10
+
+## Determine search terms
+
+**If a GitHub URL was provided:**
+1. Fetch the issue/PR with comments: `gh issue view <number> --comments` or `gh pr view <number> --comments`
+2. Extract linked issues/PRs from the body and comments (look for `#N` references, URLs)
+3. Fetch each linked issue/PR
+4. Derive search terms from titles, labels, and key discussion topics
+5. Continue to the search process below using those terms
+
+**If search terms were provided**, use those directly.
+
+**If neither**, infer search terms from:
+1. The current git branch name (split on `/` and `-`)
+2. Recent commit messages on this branch (`git log main..HEAD --oneline`)
+
+## Search process
+
+1. Search open AND closed issues (discussion often lives in closed issues):
+   ```
+   gh search issues "<terms>" --repo myyoda/principles-paper --limit <limit>
+   ```
+
+2. Search PRs:
+   ```
+   gh search prs "<terms>" --repo myyoda/principles-paper --limit <limit>
+   ```
+
+3. For each result that looks relevant, fetch the full discussion:
+   ```
+   gh issue view <number> --comments
+   gh pr view <number> --comments
+   ```
+
+4. For PRs with review comments, also fetch inline review comments:
+   ```
+   .claude/scripts/gh-pr-comments myyoda/principles-paper <number>
+   ```
+
+5. If you discover additional linked issues/PRs in the discussion that seem relevant, follow those too.
+
+## Output
+
+Return a curated summary — not a transcript. The user's main conversation should not be bloated.
+
+Structure:
+- **Issues/PRs found**: table with number, title, status, and one-line relevance note. Under each entry, include a bulleted list of relevant comments (author + key point) and any linked URLs/references.
+- **Key discussion themes**: the 3-5 most important points across all discussions
+- **Open questions**: unresolved disagreements or decisions still pending
+- **Recommendations**: if any issues/PRs are especially relevant to the current branch/task, call them out
+
+Be opinionated about what matters. Skip noise, housekeeping comments, and resolved tangents.
+
+## Save to file
+
+After composing the summary, write it to `local-notes/` (which is gitignored).
+
+**Filename**: derive from the seed input:
+- GitHub URL → `context-issue-36.md` or `context-pr-39.md`
+- Search terms → slugify the terms, e.g. `context-stamped-actionable.md`
+- No explicit seed → `context-branch-<branchname>.md`
+
+Write the full markdown summary to that file using the Write tool. Then return the summary as usual so the main conversation also sees it.


### PR DESCRIPTION
## Summary

Adds a [Claude Code skill](https://docs.anthropic.com/en/docs/claude-code/skills) that reads GitHub issue and PR discussion history into the agent's context when starting work on a topic. Addresses #36.

### What's included

- **`.claude/skills/gather-context/SKILL.md`** — The skill definition. Invoked with `/gather-context <search terms or github URL>`. It:
  1. Accepts a GitHub issue/PR URL or free-text search terms (or infers terms from the branch name)
  2. Searches issues and PRs via `gh search issues` / `gh search prs`
  3. Fetches full discussions with `gh issue view --comments` / `gh pr view --comments`
  4. Fetches inline PR review comments (where much of our substantive debate lives)
  5. Follows cross-references found in discussions
  6. Returns a curated summary — not a raw transcript — to keep the main conversation context clean
  7. Saves the summary to `local-notes/` (gitignored) for reference

- **`.claude/scripts/gh-pr-comments`** — A small bash script that fetches inline PR review comments via `gh api`. This exists as a separate script (rather than an inline `gh api` call) so that it can be pre-approved as a read-only command — the agent can run it without prompting the user for permission each time. The script only reads; it cannot modify anything upstream.

## Speeding it up with permissions

By default, Claude Code will prompt for approval on every `gh` command. You can pre-approve the read-only git/GitHub commands to let it run without interruption by adding these to your allow list:

- `gh issue view`
- `gh pr view`
- `gh search issues`
- `gh search prs`
- `.claude/scripts/gh-pr-comments` (already scoped to read-only API calls)

## Known limitations

- **Hammers the `gh` API** — Each invocation makes many API calls (search + fetch each result + fetch inline comments for PRs). For a repo with active discussion this adds up fast. Rate limiting could become an issue with heavy use.
- **Relevance filtering needs work** — The first real test (running it on #36) pulled in deep context about STAMPED definitions and terminology debates that are related to the *repo* but not to the *seed issue*. The skill needs to score relevance against the seed issue more aggressively and drop tangential results.
- **git-bug as a future improvement** — Storing GitHub discussions locally via [git-bug](https://github.com/git-bug/git-bug) would eliminate the API hammering problem entirely — the agent would just query a local database. However, git-bug supports bidirectional sync, which means we'd need to carefully restrict (not just by convention) the agent's ability to modify upstream state without explicit permission. Worth exploring but needs thought.

🤖 Generated with [Claude Code](https://claude.com/claude-code)