### PR TITLE
Revise term definitions and update usage throughout proposal

### DIFF
--- a/proposals/stamped-acronym.md
+++ b/proposals/stamped-acronym.md
@@ -6,7 +6,7 @@
 **Module**: a separately distributable collection of components.
 - Examples: datasets, software packages, container images, analysis pipeline, submodule dependence...
 
-**Component**: A trackable atomic object, part a module.
+**Component**: A trackable element that is part of a module.
 - Examples: raw data file, directory, Zarr, code, documentation, logs, records...
 - Note that a module contains components, but not every component is a module.
 


### PR DESCRIPTION
From meeting with Yarik: restructure the term hierarchy to Research Object > Module > Component (previously Research Object > Component > Asset).

Rationale:
- "Module" aligns naturally with "Modular" (the M in STAMPED)
- "Component" replaces "Asset" because the relevant quality is that it is a trackable unit, not whether it is a file, artifact, or directory

Update all references in acronym definitions, normative properties, and RFC 2119 sections to use new terminology.

@CodyCBakerPhD wanted to put this up ASAP since it will probably affect your STAMPED_PROPOSALFINAL_FINAL2_ PR