### PR TITLE
ci: update PR diff comment in place instead of creating duplicates

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -89,12 +89,21 @@ jobs:
           git commit -m "PDF preview for PR #${PR_NUMBER} (${HEAD_SHA:0:7})"
           git push -f origin "$BRANCH"
 
+      - name: Find existing diff comment
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/find-comment@v3
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- pdf-preview -->'
+
       - name: Comment on PR with PDF link and diff
         if: github.event_name == 'pull_request'
         uses: peter-evans/create-or-update-comment@v4
         with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
           body: ${{ steps.diff.outputs.body }}
           edit-mode: replace
 

--- a/main.tex
+++ b/main.tex
@@ -23,6 +23,8 @@
 
 \section{Abstract}
 
+A VISUAL CHANGE TO TEST THE CI FOR COMMENT UPDATE
+
 % TODO: compose later when other stuff filled out
 
 \section{Introduction}

--- a/main.tex
+++ b/main.tex
@@ -23,8 +23,6 @@
 
 \section{Abstract}
 
-A VISUAL CHANGE TO TEST THE CI FOR COMMENT UPDATE
-
 % TODO: compose later when other stuff filled out
 
 \section{Introduction}


### PR DESCRIPTION
Use peter-evans/find-comment to locate the existing diff comment by its <!-- pdf-preview --> sentinel before posting, so subsequent pushes update the same comment rather than appending new ones.