### PR TITLE
Remove trailing periods in listings + extend wording on modular one

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -240,51 +240,51 @@ Toward the ideal end, several complementary strategies reduce the risk that exte
 \hline
 \textbf{To be Self-contained:} &
 \begin{itemize}[noitemsep,topsep=0pt,leftmargin=*]
-  \item all modules and components needed to understand and execute the Research Object are retrievable as a single unit.
-  \item external dependencies are explicitly documented with retrieval instructions.
-  \item there are no implicit references to undocumented external resources.
+  \item all modules and components needed to understand and execute the Research Object are retrievable as a single unit
+  \item external dependencies are explicitly documented with retrieval instructions
+  \item there are no implicit references to undocumented external resources
 \end{itemize} \\
 \hline
 \textbf{To be Tracked:} &
 \begin{itemize}[noitemsep,topsep=0pt,leftmargin=*]
-  \item every component has version information (commit hash, tag, or identifier).
-  \item changes to components are recorded with timestamps and authorship.
-  \item provenance records capture the computational history, context, and transformations.
+  \item every component has version information (commit hash, tag, or identifier)
+  \item changes to components are recorded with timestamps and authorship
+  \item provenance records capture the computational history, context, and transformations
 \end{itemize} \\
 \hline
 \textbf{To be Actionable:} &
 \begin{itemize}[noitemsep,topsep=0pt,leftmargin=*]
-  \item instructions for executing procedures are present and unambiguous.
-  \item execution paths can be followed manually or automated programmatically.
-  \item the Research Object transitions from documentation to operational capability.
+  \item instructions for executing procedures are present and unambiguous
+  \item execution paths can be followed manually or automated programmatically
+  \item the Research Object transitions from documentation to operational capability
 \end{itemize} \\
 \hline
 \textbf{To be Modular:} &
 \begin{itemize}[noitemsep,topsep=0pt,leftmargin=*]
-  \item modules can be independently modified.
-  \item components are organized in logical, separable units.
-  \item modules can be composed together or used in isolation.
+  \item modules can be independently tracked, modified, and distributed
+  \item components are organized in logical, separable units
+  \item modules can be composed together or used in isolation
 \end{itemize} \\
 \hline
 \textbf{To be Portable:} &
 \begin{itemize}[noitemsep,topsep=0pt,leftmargin=*]
-  \item system requirements and dependencies are explicitly documented.
-  \item the Research Object is flexible enough to execute on different host environments without modification by the user.
-  \item environment specifications are machine-readable where possible.
+  \item system requirements and dependencies are explicitly documented
+  \item the Research Object is flexible enough to execute on different host environments without modification by the user
+  \item environment specifications are machine-readable where possible
 \end{itemize} \\
 \hline
 \textbf{To be Ephemeral:} &
 \begin{itemize}[noitemsep,topsep=0pt,leftmargin=*]
-  \item computation can occur in temporary, disposable environments.
-  \item results are reproducible without knowledge of previous runs.
-  \item no reliance on external configurations or host system states (such as OS registry modifications).
+  \item computation can occur in temporary, disposable environments
+  \item results are reproducible without knowledge of previous runs
+  \item no reliance on external configurations or host system states (such as OS registry modifications)
 \end{itemize} \\
 \hline
 \textbf{To be Distributable:} &
 \begin{itemize}[noitemsep,topsep=0pt,leftmargin=*]
-  \item all modules and components can be shared in a persistent, retrievable state.
-  \item dependencies are frozen or pinned to specific versions across systems.
-  \item the Research Object can be obtained by others in the same state as intended.
+  \item all modules and components can be shared in a persistent, retrievable state
+  \item dependencies are frozen or pinned to specific versions across systems
+  \item the Research Object can be obtained by others in the same state as intended
 \end{itemize} \\
 \hline
 \end{tabular}


### PR DESCRIPTION
periods -- not needed as bullets separate and odd, since next item starts with lower case letter

I could not go by requirement for modules just to be modified separattely and thus immediately related to existing other properties of tracked and distributable