### PR TITLE
Examples section

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -343,7 +343,7 @@ The tools that serve multiple properties do so precisely because they operationa
 
 Table~\ref{tab:stamped-tools} maps some commonly used tools and technologies to each STAMPED property.
 A comprehensive up-to-date review of existing tools is out of scope for this formalization paper and would quickly become outdated.
-To fill that niche, we initiated a satellite project with a website to describe tools and examples, and characterize them in terms of STAMPED and FAIR principles [cite https://stamped-principles.github.io/stamped-examples/stamped\_principles/].
+To fill that niche, we initiated a satellite project with a website to describe tools and examples, and characterize them in terms of STAMPED and FAIR principles [cite https://examples.stamped-principles.org/stamped\_principles/].
 
 STAMPED properties are tool-agnostic. For example, any system that moves a property from documented to executable moves the research object further along the actionability spectrum, but certain tool categories recur across multiple properties; a well-chosen tool can address several dimensions at once, and a thoughtfully assembled toolchain can cover all of them.
 Researchers should select tools based on their domain, infrastructure, and team familiarity, recognizing that the tools listed here are illustrative rather than prescriptive: what matters is that the underlying property is satisfied, regardless of which tool achieves it.
@@ -519,7 +519,7 @@ This is less a change to STAMPED itself than a call on these communities: Tracki
 
 STAMPED compliance today is self-assessed against the checklist provided in this paper and shared at \url{https://github.com/stamped-principles/stamped-checklist}.
 Broader adoption will depend on promotion and external incentives: funder mandates (e.g.,\ NIH Data Management and Sharing policies), journal reproducibility badges\cite{center_for_open_science_open_2023}, and venue-level review checklists that converge toward automated scoring --- paralleling the trajectory of FAIR, which has moved from principles to machine-assessable indicators with tools such as F-UJI\cite{devaraju_automated_2021}.
-No tool certifies STAMPED compliance today; a community-maintained benchmark suite, seeded by the satellite examples project associated with this paper (\url{https://stamped-principles.github.io/stamped-examples}), is a natural precursor.
+No tool certifies STAMPED compliance today; a community-maintained benchmark suite, seeded by the satellite examples project associated with this paper (\url{https://examples.stamped-principles.org}), is a natural precursor.
 
 \subsubsection{Teaching and onboarding}
 

--- a/main.tex
+++ b/main.tex
@@ -402,6 +402,13 @@ Archive and persistently host frozen, versioned research objects and their compo
 % TODO: point to living documentation, minimal examples/counter-examples
 % TODO: FAIRly big workflow, AIND, non-neuroscience examples?
 
+\subsubsection{Pedagogical examples}
+
+To complement the formal definitions above, the satellite examples project (\url{https://examples.stamped-principles.org}) walks the reader through the STAMPED properties using small, concrete worked examples.
+The pages tagged ``introduction'' (\url{https://examples.stamped-principles.org/tags/introduction/}) trace how each property applies to the same simple research object, providing a gentle on-ramp before the real-world adoptions below.
+
+\subsubsection{Real-world adoptions}
+
 Several research projects have already adopted and documented YODA principles---the predecessor to STAMPED---demonstrating practical utility across domains.
 
 \textbf{BIDS Standard Evolution}: A significant validation of the ``do not look up'' principle occurred within the Brain Imaging Data Structure (BIDS)\cite{gorgolewski_brain_2016} community.


### PR DESCRIPTION
Links to "introduction" tag, which doesnt actually exist until https://github.com/stamped-principles/stamped-examples/pull/23 merges.

Second commit caught some outdated links. 