### PR TITLE
[ENH]: Avoid pointing to github, added 'stamped-checklist-schema:v0.1.0' properly to Zotero library

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -317,7 +317,7 @@ Toward the ideal end, several complementary strategies reduce the risk that exte
 We hope that the preceding sections have provided a clear understanding of the STAMPED principles and their rationale.
 While this understanding is essential, researchers may also benefit from a practical checklist to assess their research objects against these principles.
 Similar to the living examples repository, an interactive checklist has been provided at the webpage \url{https://checklist.stamped-principles.org} to guide assessments of compliance with STAMPED principles, ordered by the strength of the requirement (MUST, SHOULD, MAY).
-The schema for this checklist is itself a living, version-tracked entity \cite{stamped-checklist} that is likely to grow over time as more common violations of the principles are discovered in practice.
+The schema for this checklist is itself a living, version-tracked entity \cite{stamped-checklist-schema:v0.1.0} that is likely to grow over time as more common violations of the principles are discovered in practice.
 
 \begin{figure}[htbp]
 \centering
@@ -530,7 +530,7 @@ This is less a change to STAMPED itself than a call on these communities: Tracki
 
 \subsubsection{Adoption incentives and tool certification}
 
-STAMPED compliance today is self-assessed against the checklist fulfilling a simple LinkML model\cite{stamed-checklist}, which then presented in this paper, and exposed to users in a convenient Web UI at \url{https://checklist.stamped-principles.org}.
+STAMPED compliance today is self-assessed against the checklist fulfilling a simple LinkML model\cite{stamped-checklist-schema:v0.1.0}, which then presented in this paper, and exposed to users in a convenient Web UI at \url{https://checklist.stamped-principles.org}.
 That Web UI provides self-contained stateful permalinks to render any particular state of the filled out checklist, so they could be shared easily.
 Broader adoption will depend on promotion and external incentives, including funder mandates (e.g.,\ NIH Data Management and Sharing policies), journal reproducibility badges\cite{center_for_open_science_open_2023}, and venue-level review checklists that converge toward automated scoring. 
 Such a trajectory would parallel that of FAIR, which has moved from principles to machine-assessable indicators with tools such as F-UJI\cite{devaraju_automated_2021}.

--- a/main.tex
+++ b/main.tex
@@ -316,7 +316,7 @@ Toward the ideal end, several complementary strategies reduce the risk that exte
 
 We hope that the preceding sections have provided a clear understanding of the STAMPED principles and their rationale.
 While this understanding is essential, researchers may also benefit from a practical checklist to assess their research objects against these principles.
-Similar to the living examples repository, an interactive checklist has been provided at the webpage https://checklist.stamped-principles.org to guide assessments of compliance with STAMPED principles, ordered by the strength of the requirement (MUST, SHOULD, MAY).
+Similar to the living examples repository, an interactive checklist has been provided at the webpage \url{https://checklist.stamped-principles.org} to guide assessments of compliance with STAMPED principles, ordered by the strength of the requirement (MUST, SHOULD, MAY).
 The schema for this checklist is itself a living, version-tracked entity \cite{stamped-checklist} that is likely to grow over time as more common violations of the principles are discovered in practice.
 
 \begin{figure}[htbp]
@@ -530,7 +530,8 @@ This is less a change to STAMPED itself than a call on these communities: Tracki
 
 \subsubsection{Adoption incentives and tool certification}
 
-STAMPED compliance today is self-assessed against the checklist provided in this paper and shared at \url{https://github.com/stamped-principles/stamped-checklist}.
+STAMPED compliance today is self-assessed against the checklist fulfilling a simple LinkML model\cite{stamed-checklist}, which then presented in this paper, and exposed to users in a convenient Web UI at \url{https://checklist.stamped-principles.org}.
+That Web UI provides self-contained stateful permalinks to render any particular state of the filled out checklist, so they could be shared easily.
 Broader adoption will depend on promotion and external incentives, including funder mandates (e.g.,\ NIH Data Management and Sharing policies), journal reproducibility badges\cite{center_for_open_science_open_2023}, and venue-level review checklists that converge toward automated scoring. 
 Such a trajectory would parallel that of FAIR, which has moved from principles to machine-assessable indicators with tools such as F-UJI\cite{devaraju_automated_2021}.
 No automated tool yet available as of now certifies STAMPED compliance.

--- a/references.bib
+++ b/references.bib
@@ -1560,6 +1560,22 @@
 	note = {Published: Software, GitHub repository},
 }
 
+@misc{stamped-checklist-schema:v0.1.0,
+	title = {stamped-principles/stamped-checklist-schema: v0.1.0},
+	copyright = {Creative Commons Attribution 4.0 International},
+	shorttitle = {stamped-principles/stamped-checklist-schema},
+	url = {https://zenodo.org/doi/10.5281/zenodo.19672391},
+	doi = {10.5281/ZENODO.19672391},
+	abstract = {v0.1.0
+
+First alpha release of the STAMPED checklist schema.},
+	urldate = {2026-05-15},
+	publisher = {Zenodo},
+	author = {Cody Baker},
+	month = apr,
+	year = {2026},
+}
+
 @article{gentleman_statistical_2007,
 	title = {Statistical {Analyses} and {Reproducible} {Research}},
 	volume = {16},
@@ -1903,15 +1919,17 @@
 	title = {The {OpenNeuro} resource for sharing of neuroscience data},
 	volume = {10},
 	issn = {2050-084X},
-	url = {https://elifesciences.org/articles/71774},
+	url = {https://doi.org/10.7554/eLife.71774},
 	doi = {10.7554/eLife.71774},
 	abstract = {The sharing of research data is essential to ensure reproducibility and maximize the impact of public investments in scientific research. Here, we describe OpenNeuro, a BRAIN Initiative data archive that provides the ability to openly share data from a broad range of brain imaging data types following the FAIR principles for data sharing. We highlight the importance of the Brain Imaging Data Structure standard for enabling effective curation, sharing, and reuse of data. The archive presently shares more than 600 datasets including data from more than 20,000 participants, comprising multiple species and measurement modalities and a broad range of phenotypes. The impact of the shared data is evident in a growing number of published reuses, currently totalling more than 150 publications. We conclude by describing plans for future development and integration with other ongoing open science efforts.},
-	language = {en},
-	urldate = {2025-08-14},
+	urldate = {2023-06-28},
 	journal = {eLife},
+	publisher = {eLife Sciences Publications, Ltd},
 	author = {Markiewicz, Christopher J and Gorgolewski, Krzysztof J and Feingold, Franklin and Blair, Ross and Halchenko, Yaroslav O and Miller, Eric and Hardcastle, Nell and Wexler, Joe and Esteban, Oscar and Goncavles, Mathias and Jwa, Anita and Poldrack, Russell},
+	editor = {Kahnt, Thorsten and Baker, Chris I and Dosenbach, Nico and Hawrylycz, Michael J and Svoboda, Karel},
 	month = oct,
 	year = {2021},
+	keywords = {EEG, MEG, MRI, data sharing, neuroimaging, open science},
 	pages = {e71774},
 }
 
@@ -2158,15 +2176,4 @@
 	author = {Hanke, Michael and Visconti di Oleggio Castello, Matteo and Meyer, Kyle and Poldrack, Benjamin and Halchenko, Yaroslav O.},
 	year = {2018},
 	note = {Published: Poster presented at the annual meeting of the Organization for Human Brain Mapping, Singapore},
-}
-
-@software{stamped-checklist,
-	author = {Baker, Cody},
-	title = {{stamped-principles/stamped-checklist-schema: v0.1.0}},
-	month = apr,
-	year = 2026,
-	publisher = {Zenodo},
-	version = {v0.1.0},
-	doi = {10.5281/zenodo.19672391},
-	url = {https://doi.org/10.5281/zenodo.19672391}
 }


### PR DESCRIPTION
all references should be added to Zotero and then `make -B references.bib` fetched/populated in the repo.

Within zotero I just imported zenodo DOI to get record "automagically" created.  Ideally, we should provide CITATION.cff or .zenodo.json (like @vmdocua just did for https://github.com/ReproNim/reprostim/blob/master/.zenodo.json and reference grants info etc), so I did not sweat to tune it much

Then, to avoid custom long keys for exported records, it is possible to provide custom key within Zotero record:

<img width="1250" height="48" alt="image" src="https://github.com/user-attachments/assets/a725af79-4162-476b-9f4b-9903fc9b15d3" />

so I did that online and as a result it came nice to the .bib . But may be we would want to create and curate one without version info in it?