### PR TITLE
Acknowledge YODA poster and VAMP authors as foundational works

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -637,6 +637,9 @@ The authors declare no competing interests.
 
 \anchoredsection{acknowledgments}{Acknowledgments}
 
+STAMPED builds directly on prior community efforts to articulate principles for reproducible research data management.
+We are grateful to Michael Hanke and Adina S.\ Wagner for the conceptual development of VAMP\cite{hanke_what_2023}, and to the authors of the original YODA poster\cite{hanke_yoda_2018}---Michael Hanke, Matteo Visconti di Oleggio Castello, Kyle Meyer, and Benjamin Poldrack---whose work laid the foundations on which this formalization rests.
+
 This manuscript and companion materials in the \href{STAMPED Principles GitHub organization}{https://github.com/stamped-principles/} were prepared with the assistance of agentic AI coding tools and large language models (primarily Claude Opus).
 All final text, figures, and specifications were edited and/or confirmed by the human authors, who are responsible for the content.
 Where AI tools notably contributed to a change, we have strived to annotate the corresponding commits with a \texttt{Co-Authored-By} trailer, or analogous comments, to identify the tool and potentially the model version, so that the provenance of individual contributions is inspectable in the public git history of the \texttt{stamped-*} repositories.


### PR DESCRIPTION
Add a paragraph to the Acknowledgments section thanking Michael Hanke and Adina S. Wagner for the conceptual development of VAMP, and the authors of the original YODA poster (Hanke, Visconti di Oleggio Castello, Meyer, Poldrack), placed before the AI-assistance note.

attn @mih @adswa -- I would still welcome you into co-authors here if you like!  I am sure your input and persppectives could make this manuscript etc more solid.