### PR TITLE
Adjust code text formatting

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -407,7 +407,7 @@ Git submodules, DataLad subdatasets, Kedro &
 Organize components into independently versioned, composable modules; provide project templates with logical directory separation \\
 \hline
 \textbf{Portability (P)} &
-Docker, Singularity, Nix, conda, pip (\texttt{pyproject.toml}, \texttt{requirements.txt}), npm &
+Docker, Singularity, Nix, \texttt{conda}, \texttt{pip} (\texttt{pyproject.toml}, \texttt{requirements.txt}), \texttt{npm} &
 Explicitly specify and isolate computational environments; container-based (OS-level isolation) or package-based (declarative, reproducible builds) \\
 \hline
 \textbf{Ephemerality (E)} &


### PR DESCRIPTION
close #151 

Think these are the only ones

Technically, the use here on the table is in reference to the CLI packages not the parent software (e.g., Node, Conda)