### PR TITLE
Licensing and allusions to certifications

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -260,6 +260,7 @@ Nonetheless, the principle substantially raises confidence that the research obj
 \begin{itemize}
     \item \textbf{D.1}: All referenced modules and components MUST be persistently retrievable by others.
     \item \textbf{D.2}: Environment specifications SHOULD support reproducible builds.
+    \item \textbf{D.3}: Each module SHOULD carry an explicit license with a resolvable identifier.
 \end{itemize}
 
 A research object that is Self-contained~(S) on the author's machine but cannot be obtained by others in the same state is effectively unreproducible beyond its origin.
@@ -272,6 +273,8 @@ A distributable research object is packaged so that it can be retrieved in the s
 
 Distributability also has a circular relationship with the other STAMPED principles in that someone else's distribution effort often serves as the starting point for a new research object's Self-containment~(S).
 Researchers routinely begin by downloading containers, fetching published datasets, and installing released software---Modularly~(M) composing the distributions of others to assemble their own Self-contained~(S) research objects.
+Though persistent retrievability is a necessary but not sufficient condition for redistribution.
+Additionally, each module should carry an easily identifiable license or set of licenses for any bundled assets (e.g., via SPDX identifiers\cite{} or the REUSE specification\cite{}) so that downstream researchers can compose, modify, and re-share components without legal ambiguity.
 
 The spectrum of distributability begins where FAIR leaves off, with publicly accessible components and documented retrieval instructions.
 Toward the ideal end, several complementary strategies reduce the risk that external changes will break a research object's reproducibility.

--- a/main.tex
+++ b/main.tex
@@ -154,7 +154,6 @@ For tracking to be effective, all components of the research object must be unde
 
 Traditional version control is designed for code and other text files, but research objects often include large binary datasets, container images, and other assets that do not fit this model.
 Compatible tools such as git-annex, DataLad\cite{halchenko_datalad_2021}, or DVC\cite{ruslan_kuprieiev_dvc_2026} extend content-addressed tracking to these components, ensuring that all parts of the research object are managed under the same system.
-Cryptographic signatures (e.g., signed git commits and tags, sigstore-signed releases, in-toto attestations) strengthen these records from self-reported to verifiable, allowing recipients to confirm that components and changes originate from the claimed identities.
 
 Toward the ideal end, provenance is captured programmatically by tooling rather than by manual annotation.
 Each computational step should record exactly what command was executed and what inputs were consumed, producing richer and more reliable records than a human would typically write.

--- a/main.tex
+++ b/main.tex
@@ -137,8 +137,7 @@ Tracking~(T), Modularity~(M), Portability~(P), and Distributability~(D) each add
     \item \textbf{T.1}: Persistent content identification MUST be recorded for all components.
     \item \textbf{T.2}: All components SHOULD be tracked using the same content-addressed version control system.
     \item \textbf{T.3}: Provenance of all modifications MUST be recorded.
-    \item \textbf{T.4}: Code-driven provenance SHOULD be recorded programmatically and MUST include the versions of
-    all components involved.
+    \item \textbf{T.4}: Code-driven provenance SHOULD be recorded programmatically and MUST include the versions of all components involved.
 \end{itemize}
 
 Research data and code change constantly during a project, and each change compounds the difficulty of reconstructing any previous state, such as which version of a dataset was used for a particular analysis, what parameters were set, and what code produced a given figure.
@@ -149,11 +148,13 @@ The spectrum of Tracking begins with content-addressed version control.
 Rather than relying on semantic version labels, content-addressed systems identify each state by a checksum of its contents.
 This distinction matters; two datasets labeled ``version 1.0'' by different labs are ambiguous whereas two datasets with identical content hashes are provably identical.
 Version control commits also capture basic provenance of who made the change, when, and a description of why.
+Cryptographic signatures (e.g., signed git commits and tags, sigstore-signed releases) strengthen these records from self-reported to verifiable, allowing recipients to confirm that components and changes originate from the claimed identities.
 This unifies identity and provenance in a single system and also provides a safety net since any change can be reverted and any prior state restored, making it easier to modify and experiment.
 For tracking to be effective, all components of the research object must be under version control: code, data, environment definitions, and configuration.
 
 Traditional version control is designed for code and other text files, but research objects often include large binary datasets, container images, and other assets that do not fit this model.
 Compatible tools such as git-annex, DataLad\cite{halchenko_datalad_2021}, or DVC\cite{ruslan_kuprieiev_dvc_2026} extend content-addressed tracking to these components, ensuring that all parts of the research object are managed under the same system.
+Cryptographic signatures (e.g., signed git commits and tags, sigstore-signed releases, in-toto attestations) strengthen these records from self-reported to verifiable, allowing recipients to confirm that components and changes originate from the claimed identities.
 
 Toward the ideal end, provenance is captured programmatically by tooling rather than by manual annotation.
 Each computational step should record exactly what command was executed and what inputs were consumed, producing richer and more reliable records than a human would typically write.
@@ -283,6 +284,8 @@ Additionally, each module should carry an easily identifiable license or set of 
 The spectrum of distributability begins where FAIR leaves off, with publicly accessible components and documented retrieval instructions.
 Toward the ideal end, several complementary strategies reduce the risk that external changes will break a research object's reproducibility.
 Bundling dependencies into containers or archives reduces the surface area of components that can independently change or disappear; hosting on archival infrastructure (Zenodo, DANDI, Software Heritage) with content-addressed identifiers allows recipients to verify integrity regardless of source; mirroring across multiple platforms protects against the failure of any single registry.
+Where downstream consumers must verify not only integrity but also origin and build process, signed releases and supply-chain attestations (e.g., sigstore, in-toto, SLSA) provide cryptographic evidence that an artifact was produced by the claimed identity from the claimed sources.
+This becomes important when distributed artifacts will execute in environments enforcing code-signing policies, such as notarization or signed container admission.
 
 \begin{table}[htbp]
 \centering

--- a/main.tex
+++ b/main.tex
@@ -113,6 +113,7 @@ The items containing keywords "MUST", "SHALL", "SHOULD", and "MAY" are to be int
 
 \begin{itemize}
     \item \textbf{S.1}: All modules and components essential to replicate computational execution MUST be reachable within a single top-level research object.
+    \item \textbf{S.2}: License declarations for all components are themselves part of the research object and MUST be retrievable alongside the content they govern.
 \end{itemize}
 
 Reproducibility fails when a research object depends on resources that are not part of it; an undocumented library, a dataset referenced by a broken URL, a script that assumes tools are installed on the host system.
@@ -195,6 +196,7 @@ A SciOps-style workflow makes hand-offs between experimental, analytical, and en
 \begin{itemize}
     \item \textbf{M.1}: Components SHOULD be organized in a modular structure.
     \item \textbf{M.2}: Components MAY be included directly or linked as subdatasets.
+    \item \textbf{M.3}: Each module's license SHOULD be declared independently and checked for compatibility at the boundaries where modules are combined
 \end{itemize}
 
 Separation of concerns is a foundational engineering practice: organizing a system so that each piece has a clear, distinct role.
@@ -203,7 +205,9 @@ We define a \textbf{module} as a separately Distributable~(D) unit of a research
 This can include a subdataset, a collection of analysis scripts, or the definition for some computational environment.
 In practice, module boundaries often align with repository boundaries, but a module may also be a published container, a registered dataset, or any independently versioned unit.
 Modularity applies this principle to research objects, structuring them as assemblies of modules whose boundaries are explicit.
-At a minimum, a research object should separate analysis code, input datasets, computational environments, configuration settings, and results into distinct directories.
+Module boundaries are also where license compatibility must be checked, since combining modules with incompatible terms can prevent the assembled research object from being lawfully redistributed.
+
+At a minimum, a research object should separate analysis code, input datasets, computational environments, licenses, configuration settings, and results into distinct directories.
 Beyond this, independent versioning of modules enables reuse; a dataset or environment can be updated to a newer version, or swapped for an alternative, without disrupting the rest of the research object.
 This is possible through manual management but becomes practical when handled by tooling that automates module installation, versioning, and composition.
 Toward the ideal end, the full research object can be reassembled from its specification through automated, recursive installation of its modules.
@@ -274,7 +278,7 @@ A distributable research object is packaged so that it can be retrieved in the s
 Distributability also has a circular relationship with the other STAMPED principles in that someone else's distribution effort often serves as the starting point for a new research object's Self-containment~(S).
 Researchers routinely begin by downloading containers, fetching published datasets, and installing released software---Modularly~(M) composing the distributions of others to assemble their own Self-contained~(S) research objects.
 Though persistent retrievability is a necessary but not sufficient condition for redistribution.
-Additionally, each module should carry an easily identifiable license or set of licenses for any bundled assets (e.g., via SPDX identifiers\cite{} or the REUSE specification\cite{}) so that downstream researchers can compose, modify, and re-share components without legal ambiguity.
+Additionally, each module should carry an easily identifiable license or set of licenses for any bundled assets (e.g., via SPDX identifiers\cite{stewart_software_2010} or the REUSE specification\cite{fsfe_reuse_2024}) so that downstream researchers can compose, modify, and re-share components without legal ambiguity.
 
 The spectrum of distributability begins where FAIR leaves off, with publicly accessible components and documented retrieval instructions.
 Toward the ideal end, several complementary strategies reduce the risk that external changes will break a research object's reproducibility.

--- a/references.bib
+++ b/references.bib
@@ -2465,3 +2465,22 @@ First alpha release of the STAMPED principles schema.},
 	year = {2018},
 	note = {Published: Poster presented at the annual meeting of the Organization for Human Brain Mapping, Singapore},
 }
+
+@article{stewart_software_2010,
+  author = {Stewart, Kate and Odence, Phil and Rockett, Esteban},
+  title = {Software Package Data Exchange ({SPDX}) Specification},
+  journal = {International Free and Open Source Software Law Review},
+  volume = {2},
+  number = {2},
+  pages = {191--196},
+  year = {2010},
+  do = {10.5033/ifosslr.v2i2.45},
+  url = {https://www.ifosslr.org/ifosslr/article/view/45}
+}
+
+@misc{fsfe_reuse_2024,
+  author = {{Free Software Foundation Europe}},
+  title = {{REUSE} Specification, Version 3.3},
+  year = {2024},
+  url = {https://reuse.software/spec-3.3/}
+}


### PR DESCRIPTION
closes #135 

Keeping it very brief

Licensing most naturally fits REUSE-style requirements in the relevant sections. Was so obvious to us I suppose that we just forgot about it until now (usually the first thing we include in our own new projects and first thing we check when finding new ones)

Certification does not really fit as a requirement anywhere since it is very much an 'extra' thing that most people actively avoid unless they need it, but fits broadly into the concept of provenance and distribution so added mention there