### PR TITLE
Review suggestions: wording, Table 1, structure, and consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Associated examples: [stamped-principles.github.io/stamped-examples](https://sta
 
 Target venue: **Nature Scientific Data** (Article format).
 
-See [CLAUDE.md](CLAUDE.md) for project conventions and file map.
+See [.claude/CLAUDE.md](.claude/CLAUDE.md) for project conventions and file map.
 
 ## Licensing
 

--- a/main.tex
+++ b/main.tex
@@ -469,7 +469,7 @@ The pages tagged ``STAMPED-intro'' (\httpsurl{examples.stamped-principles.org/ta
 Several research projects have already adopted and documented the YODA principles (the predecessor to STAMPED) demonstrating practical utility across domains.
 
 \textbf{BIDS Standard Evolution}: A significant validation of the ``do not look up'' principle occurred within the Brain Imaging Data Structure (BIDS)\cite{gorgolewski_brain_2016} community.
-Originally, the BIDS specification nested derived data under \texttt{derivatives/} within the original raw dataset, creating upward dependencies that violated Modularity~(M) and, as a consequence, Portability~(P).
+Originally, the BIDS specification nested derived data under \texttt{derivatives/} within the original raw dataset, creating upward dependencies that violated Self-containment~(S) and Modularity~(M), which broke Portability~(P).
 Following YODA principles, the BIDS community reversed this relationship so that derivative datasets now exist independently and reference raw data as subdatasets, not vice versa.
 
 This architectural shift influenced major neuroimaging tools:

--- a/main.tex
+++ b/main.tex
@@ -85,10 +85,6 @@ A researcher who stores everything under one project directory, version-controls
 As complexity grows, such as for multi-institutional collaborations with heterogeneous workflows spanning platforms enforcing long-term reproducibility, these same principles guide researchers toward more rigorous practices without requiring wholesale adoption of new tools.
 STAMPED provides a descriptive vocabulary and a framework for evaluation that can incrementally improve the operational properties of research objects towards enhanced rigor, reproducibility, reusability, transparency, and efficiency.
 
-The remainder of this article is organized as follows.
-We first present the seven STAMPED principles, each with formal requirements, a motivating rationale, and a spectrum from practical minimum to aspirational ideal.
-We then provide a checklist for self-assessment, a survey of enabling tools, and examples of real-world adoption.
-Finally, we situate STAMPED within the broader landscape of convergent practices in data-driven science and outline future directions.
 
 \begin{figure}[htbp]
 \centering

--- a/main.tex
+++ b/main.tex
@@ -105,13 +105,13 @@ STAMPED provides a descriptive vocabulary and a framework for evaluation that ca
 \hline
 \textbf{Letter} & \textbf{Principle} & \textbf{Description} \\
 \hline
-S & Self-containment & A research object contains all modules and components needed to understand and reproduce its results, without relying on external resources. \\
-T & Tracking & Every component's identity and provenance are recorded and version-controlled. \\
-A & Actionability & The research object provides sufficient information to carry out all procedures needed to obtain and reproduce its content. \\
-M & Modularity & The research object is organized into independent, reusable modules with explicit boundaries. \\
-P & Portability & The research object can be moved to different host systems while retaining its STAMPED properties. \\
-E & Ephemerality & Procedural execution can be performed within a throwaway environment. \\
-D & Distributability & All modules and procedures are shareable with others in a persistent state. \\
+S & Self-containment & A research object is a complete retrieval unit; it can be obtained and understood in its intended scope without needing to reference external resources. \\
+T & Tracking & The state and provenance of all components is recorded. \\
+A & Actionability & Research object contains machine-actionable information to carry out procedures to obtain or reproduce content. \\
+M & Modularity & All modules are independent and composable. \\
+P & Portability & Research object could be moved to different environments while retaining its STAMPED properties. \\
+E & Ephemerality & Procedural execution is performed within a throwaway environment. \\
+D & Distributability & All modules and procedures are shareable externally in a persistent state. \\
 \hline
 \end{tabular}
 \end{table}
@@ -138,7 +138,7 @@ This ensures that nothing is implicitly assumed about the host system, a concern
 At the ideal end, every reference is precise enough that retrieval is unambiguous; how to achieve that precision is the concern of Tracking~(T) and Distributability~(D).
 
 Self-containment is the foundation upon which the remaining STAMPED principles are built.
-Tracking~(T), Actionability~(A), Modularity~(M), Portability~(P), Ephemerality~(E), and Distributability~(D) each address a different aspect of how that content is structured, versioned, and shared---but none are meaningful without first establishing what is inside it.
+Tracking~(T), Modularity~(M), Portability~(P), and Distributability~(D) each address a different aspect of how that boundary is organized, versioned, and shared---but none are meaningful without first establishing what is inside it.
 
 
 
@@ -146,8 +146,8 @@ Tracking~(T), Actionability~(A), Modularity~(M), Portability~(P), Ephemerality~(
 
 \begin{itemize}
     \item \textbf{T.1}: Persistent content identification MUST be recorded for all components.
-    \item \textbf{T.2}: Provenance of all modifications MUST be recorded.
-    \item \textbf{T.3}: All components SHOULD be tracked using the same content-addressed version control system.
+    \item \textbf{T.2}: All components SHOULD be tracked using the same content-addressed version control system.
+    \item \textbf{T.3}: Provenance of all modifications MUST be recorded.
     \item \textbf{T.4}: Code-driven provenance SHOULD be recorded programmatically and MUST include the versions of all components involved.
 \end{itemize}
 
@@ -168,7 +168,7 @@ Traditional version control is designed for code and other text files, but resea
 Compatible tools such as git-annex, DataLad\cite{halchenko_datalad_2021}, or DVC\cite{ruslan_kuprieiev_dvc_2026} extend content-addressed tracking to these components, ensuring that all parts of the research object are managed under the same system.
 
 Toward the ideal end, provenance is captured programmatically by tooling rather than by manual annotation.
-Each computational step should be recorded in terms of exactly what command was executed and what inputs were consumed, producing richer and more reliable records than a human would typically write.
+Each computational step should record exactly what command was executed and what inputs were consumed, producing richer and more reliable records than a human would typically write.
 When modules are independently tracked under compatible systems, the version of every module at the time of each commit is also discoverable, providing a complete picture of the state that produced a given result.
 This enables not just inspection but re-execution.
 Beyond the research object itself, knowing the state of data and code at each hand-off between experimental, analytical, and engineering stages is what allows a team to coordinate updates without losing the provenance chain---an operational view of Tracking developed by the SciOps framework\cite{johnson_sciops_2024}.
@@ -211,7 +211,7 @@ A SciOps-style workflow makes hand-offs between experimental, analytical, and en
     \item \textbf{M.3}: Each module's license SHOULD be declared independently and checked for compatibility at the boundaries where modules are combined
 \end{itemize}
 
-A research object may be Self-contained~(S) and Tracked~(T), yet when all components are interleaved in a single monolithic directory, updating one part risks breaking another, reusing a component requires extracting it by hand, and collaborators must navigate the entire object to find what they need.
+A research object may be Self-contained~(S) and Tracked~(T), yet when all components are interleaved in a single monolithic directory, it can be fragile and difficult to navigate.
 Separation of concerns is a foundational engineering practice: organizing a system so that each piece has a clear, distinct role.
 With clear boundaries between the conceptual components of a research object, it becomes more navigable and maintainable.
 We define a \textbf{module} as a separately Distributable~(D) unit of a research object.
@@ -345,14 +345,14 @@ This becomes important when distributed artifacts will execute in environments e
 \begin{itemize}[noitemsep,topsep=0pt,leftmargin=*]
   \item computation can occur in temporary, disposable environments
   \item results are reproducible without knowledge of previous runs
-  \item the environment is rebuilt from its specification before each execution, ensuring no undocumented state carries over
+  \item the environment is rebuilt from its specification before each execution, ensuring no reliance on undocumented state
 \end{itemize} \\
 \hline
 \textbf{To be Distributable:} &
 \begin{itemize}[noitemsep,topsep=0pt,leftmargin=*]
   \item all modules and components can be shared in a persistent, retrievable state
   \item dependencies are frozen or pinned to specific versions across systems
-  \item recipients can verify that what they obtained matches the intended state (e.g., via content-addressed identifiers)
+  \item the Research Object can be obtained by others in the same state as intended
 \end{itemize} \\
 \hline
 \end{tabular}
@@ -387,7 +387,8 @@ No single tool addresses all the dimensions of scientific rigor described above,
 For example, container technologies such as Docker or Singularity serve Portability by providing OS-level isolation from explicit environment specifications, enable Ephemerality~(E) by disposing per-execution environments, and facilitate Distributability~(D) by producing frozen, shareable artifacts.
 Similarly, version control systems such as Git underpin both Tracking (content-addressed identification and change history) and Self-containment (gathering all components under a single root).
 
-In practice, Self-containing~(S) all data by storing it directly within the research object may be undesired or prohibitive due to size, licensing, or privacy concerns, creating a tension with Tracking~(T), which requires that every component be identified and versioned.
+In practice, Self-containing~(S) all data by storing it directly within the research object may be undesired or prohibitive due to size, licensing, or privacy concerns.
+This creates a tension with Tracking~(T), which requires that every component be identified and versioned.
 Extensions such as git-annex, DataLad, DVC, and Git LFS strike the balance between the two principles by tracking metadata that identifies specific data versions and obtainability information instead, e.g., content checksums and URLs of remote servers that act as a source, and providing Actionable~(A) interfaces to obtain the data when necessary.
 
 This overlap is not incidental --- it reflects the interdependence of the STAMPED principles themselves.

--- a/main.tex
+++ b/main.tex
@@ -154,7 +154,7 @@ Tracking~(T), Actionability~(A), Modularity~(M), Portability~(P), Ephemerality~(
 Research data and code change constantly during a project, and each change compounds the difficulty of reconstructing any previous state, such as which version of a dataset was used for a particular analysis, what parameters were set, and what code produced a given figure.
 A Self-contained~(S) research object gathers everything needed in one place, but without a record of how each component arrived at its current state, reproducing a prior result becomes guesswork.
 Tracking addresses two concerns: 1) the identity of each component and its exact state at a point in time, and 2) \textbf{provenance}, the recorded history of the actions by which identities produced or modified it.
-These are often managed separately, which makes reproducing and validating past work harder.
+These are often managed separately, which makes validating past work harder.
 
 The spectrum of Tracking begins with content-addressed version control.
 Rather than relying on semantic version labels, content-addressed systems identify each state by a checksum of its contents.

--- a/main.tex
+++ b/main.tex
@@ -76,7 +76,7 @@ Both the FAIR and STAMPED frameworks cover overlapping concerns.
 For example, persistent identifiers serve both Findability and Tracking but accent different aspects.
 FAIR emphasizes discovery and interoperability across repositories, while STAMPED emphasizes improving the operational maturity of scientific workflows in day-to-day research practice.
 
-Many researchers already employ practices that address these operational properties, such as version control, containerized environments, organized project directories, and documented analysis steps.
+Many researchers already employ practices that address these operational properties, such as version control, containerized environments, structured project directories, and documented analysis steps.
 Yet the community lacks a shared vocabulary for referring to these ideas, evaluating how thoroughly they are applied, and communicating that evaluation to collaborators and reviewers.
 Here we provide that vocabulary by introducing seven principles which articulate how Self-contained, Tracked, Actionable, Modular, Portable, Ephemeral, and Distributable (STAMPED) a research object is, thus describing its operational maturity.
 These originate from both the YODA Principles\cite{hanke_yoda_2018}, as well as VAMP\cite{hanke_what_2023}.

--- a/main.tex
+++ b/main.tex
@@ -65,7 +65,7 @@ STAMPED gives researchers, collaborators, reviewers, and agents a common languag
 
 Data-driven research depends on specific versions of datasets, software, and computational environments, together with a record of how they were used to produce results.
 We adopt the term \textbf{research object} to denote a collection of data, code, and metadata that together represent the research as a complete unit.
-It is common for the components of a research object to be organized independently with code in one repository, data on a shared drive, environment setup in a wiki page, and provenance (the record of how results were produced) in a lab notebook.
+It is common for the components of a research object to be organized independently with code in one repository, data on a shared drive, environment setup in a wiki page, and provenance in a lab notebook.
 This separation undermines rigor, reproducibility, reusability, and efficiency.
 Even when its components are gathered in one place, a research object is often tightly coupled to specific software versions and environments which may be opaque to outside collaborators, making it difficult to reuse or redistribute.
 

--- a/main.tex
+++ b/main.tex
@@ -94,13 +94,13 @@ STAMPED provides a descriptive vocabulary and a framework for evaluation that ca
 \hline
 \textbf{Letter} & \textbf{Principle} & \textbf{Description} \\
 \hline
-S & Self-containment & A research object is a complete retrieval unit; it can be obtained and understood in its intended scope without needing to reference external resources. \\
-T & Tracking & The state and provenance of all components is recorded. \\
-A & Actionability & Research object contains machine-actionable information to carry out procedures to obtain or reproduce content. \\
-M & Modularity & All modules are independent and composable. \\
-P & Portability & Research object could be moved to different environments while retaining its STAMPED properties. \\
-E & Ephemerality & Procedural execution is performed within a throwaway environment. \\
-D & Distributability & All modules and procedures are shareable externally in a persistent state. \\
+S & Self-containment & A research object contains all modules and components needed to understand and reproduce its results, without relying on external resources. \\
+T & Tracking & Every component's identity and provenance are recorded and version-controlled. \\
+A & Actionability & The research object provides sufficient information to carry out all procedures needed to obtain and reproduce its content. \\
+M & Modularity & The research object is organized into independent, reusable modules with explicit boundaries. \\
+P & Portability & The research object can be moved to different host systems while retaining its STAMPED properties. \\
+E & Ephemerality & Procedural execution can be performed within a throwaway environment. \\
+D & Distributability & All modules and procedures are shareable with others in a persistent state. \\
 \hline
 \end{tabular}
 \end{table}

--- a/main.tex
+++ b/main.tex
@@ -131,7 +131,7 @@ This ensures that nothing is implicitly assumed about the host system, a concern
 At the ideal end, every reference is precise enough that retrieval is unambiguous; how to achieve that precision is the concern of Tracking~(T) and Distributability~(D).
 
 Self-containment is the foundation upon which the remaining STAMPED principles are built.
-Tracking~(T), Modularity~(M), Portability~(P), and Distributability~(D) each address a different aspect of how that boundary is organized, versioned, and shared---but none are meaningful without first establishing what is inside it.
+Tracking~(T), Actionability~(A), Modularity~(M), Portability~(P), Ephemerality~(E), and Distributability~(D) each address a different aspect of how that content is structured, versioned, and shared---but none are meaningful without first establishing what is inside it.
 
 
 
@@ -139,12 +139,13 @@ Tracking~(T), Modularity~(M), Portability~(P), and Distributability~(D) each add
 
 \begin{itemize}
     \item \textbf{T.1}: Persistent content identification MUST be recorded for all components.
-    \item \textbf{T.2}: All components SHOULD be tracked using the same content-addressed version control system.
-    \item \textbf{T.3}: Provenance of all modifications MUST be recorded.
+    \item \textbf{T.2}: Provenance of all modifications MUST be recorded.
+    \item \textbf{T.3}: All components SHOULD be tracked using the same content-addressed version control system.
     \item \textbf{T.4}: Code-driven provenance SHOULD be recorded programmatically and MUST include the versions of
     all components involved.
 \end{itemize}
 
+A Self-contained~(S) research object gathers everything needed in one place, but without a record of how each component arrived at its current state, reproducing a prior result becomes guesswork.
 Research data and code change constantly during a project, and each change compounds the difficulty of reconstructing any previous state, such as which version of a dataset was used for a particular analysis, what parameters were set, and what code produced a given figure.
 Tracking addresses two concerns: 1) the identity of each component and its exact state at a point in time, and 2) \textbf{provenance}, the recorded history of the actions by which identities produced or modified it.
 These are often managed separately, which makes reproducing and validating past work harder.
@@ -202,6 +203,7 @@ A SciOps-style workflow makes hand-offs between experimental, analytical, and en
     \item \textbf{M.2}: Components MAY be included directly or linked as subdatasets.
 \end{itemize}
 
+A research object may be Self-contained~(S) and Tracked~(T), yet when all components are interleaved in a single monolithic directory, updating one part risks breaking another, reusing a component requires extracting it by hand, and collaborators must navigate the entire object to find what they need.
 Separation of concerns is a foundational engineering practice: organizing a system so that each piece has a clear, distinct role.
 With clear boundaries between the conceptual components of a research object, it becomes more navigable and maintainable.
 We define a \textbf{module} as a separately Distributable~(D) unit of a research object.

--- a/main.tex
+++ b/main.tex
@@ -75,6 +75,11 @@ A researcher who stores everything under one project directory, version-controls
 As complexity grows, such as for multi-institutional collaborations with heterogeneous workflows spanning platforms enforcing long-term reproducibility, these same principles guide researchers toward more rigorous practices without requiring wholesale adoption of new tools.
 STAMPED provides a descriptive vocabulary and a framework for evaluation that can incrementally improve the operational properties of research objects towards enhanced rigor, reproducibility, reusability, transparency, and efficiency.
 
+The remainder of this article is organized as follows.
+We first present the seven STAMPED principles, each with formal requirements, a motivating rationale, and a spectrum from practical minimum to aspirational ideal.
+We then provide a checklist for self-assessment, a survey of enabling tools, and examples of real-world adoption.
+Finally, we situate STAMPED within the broader landscape of convergent practices in data-driven science and outline future directions.
+
 \begin{figure}[htbp]
 \centering
 \includegraphics[width=\textwidth]{figures/fig1.pdf}
@@ -84,7 +89,7 @@ STAMPED provides a descriptive vocabulary and a framework for evaluation that ca
 
 
 
-\anchoredsection{comments}{Comments}
+\anchoredsection{principles}{The STAMPED Principles}
 
 \begin{table}[htbp]
 \centering
@@ -105,7 +110,7 @@ D & Distributability & All modules and procedures are shareable with others in a
 \end{tabular}
 \end{table}
 
-The items containing keywords "MUST", "SHALL", "SHOULD", and "MAY" are to be interpreted as described in RFC 2119\cite{bradner_key_1997}.
+The formal requirements use the graded keywords of RFC~2119\cite{bradner_key_1997}: MUST defines the practical minimum, while SHOULD and MAY indicate progressively more aspirational practices.
 
 
 

--- a/main.tex
+++ b/main.tex
@@ -151,8 +151,8 @@ Tracking~(T), Actionability~(A), Modularity~(M), Portability~(P), Ephemerality~(
     \item \textbf{T.4}: Code-driven provenance SHOULD be recorded programmatically and MUST include the versions of all components involved.
 \end{itemize}
 
-A Self-contained~(S) research object gathers everything needed in one place, but without a record of how each component arrived at its current state, reproducing a prior result becomes guesswork.
 Research data and code change constantly during a project, and each change compounds the difficulty of reconstructing any previous state, such as which version of a dataset was used for a particular analysis, what parameters were set, and what code produced a given figure.
+A Self-contained~(S) research object gathers everything needed in one place, but without a record of how each component arrived at its current state, reproducing a prior result becomes guesswork.
 Tracking addresses two concerns: 1) the identity of each component and its exact state at a point in time, and 2) \textbf{provenance}, the recorded history of the actions by which identities produced or modified it.
 These are often managed separately, which makes reproducing and validating past work harder.
 

--- a/main.tex
+++ b/main.tex
@@ -330,14 +330,14 @@ Bundling dependencies into containers or archives reduces the surface area of co
 \begin{itemize}[noitemsep,topsep=0pt,leftmargin=*]
   \item computation can occur in temporary, disposable environments
   \item results are reproducible without knowledge of previous runs
-  \item no reliance on any external configuration or host system state (such as OS registry modification)
+  \item the environment is rebuilt from its specification before each execution, ensuring no undocumented state carries over
 \end{itemize} \\
 \hline
 \textbf{To be Distributable:} &
 \begin{itemize}[noitemsep,topsep=0pt,leftmargin=*]
   \item all modules and components can be shared in a persistent, retrievable state
   \item dependencies are frozen or pinned to specific versions across systems
-  \item the Research Object can be obtained by others in the same state as intended
+  \item recipients can verify that what they obtained matches the intended state (e.g., via content-addressed identifiers)
 \end{itemize} \\
 \hline
 \end{tabular}

--- a/main.tex
+++ b/main.tex
@@ -55,7 +55,7 @@
 
 Data-driven research depends on specific versions of datasets, software, and computational environments, together with a record of how they were used to produce results.
 We adopt the term \textbf{research object} to denote a collection of data, code, and metadata that together represent the research as a complete unit.
-It is common for the components of a research object to be organized independently with code in one repository, data on a shared drive, environment setup in a wiki page, and provenance in a lab notebook.
+It is common for the components of a research object to be organized independently with code in one repository, data on a shared drive, environment setup in a wiki page, and provenance (the record of how results were produced) in a lab notebook.
 This separation undermines rigor, reproducibility, reusability, and efficiency.
 Even when its components are gathered in one place, a research object is often tightly coupled to specific software versions and environments which may be opaque to outside collaborators, making it difficult to reuse or redistribute.
 
@@ -66,14 +66,14 @@ Both the FAIR and STAMPED frameworks cover overlapping concerns.
 For example, persistent identifiers serve both Findability and Tracking but accent different aspects.
 FAIR emphasizes discovery and interoperability across repositories, while STAMPED emphasizes improving the operational maturity of scientific workflows in day-to-day research practice.
 
-Many researchers already employ practices that address these operational properties, such as version control, containerized environments, structured project directories, and documented analysis steps.
+Many researchers already employ practices that address these operational properties, such as version control, containerized environments, organized project directories, and documented analysis steps.
 Yet the community lacks a shared vocabulary for referring to these ideas, evaluating how thoroughly they are applied, and communicating that evaluation to collaborators and reviewers.
 Here we provide that vocabulary by introducing seven principles which articulate how Self-contained, Tracked, Actionable, Modular, Portable, Ephemeral, and Distributable (STAMPED) a research object is, thus describing its operational maturity.
 These originate from both the YODA Principles\cite{hanke_yoda_2018}, as well as VAMP\cite{hanke_what_2023}.
 Rather than a compliance threshold, each STAMPED principle is a spectrum from a practical minimum---often what researchers are already doing---to an aspirational ideal.
 A researcher who stores everything under one project directory, version-controls analysis scripts, and documents how to run them is already meeting the practical minimum for Self-containment, Tracking, and Actionability.
 As complexity grows, such as for multi-institutional collaborations with heterogeneous workflows spanning platforms enforcing long-term reproducibility, these same principles guide researchers toward more rigorous practices without requiring wholesale adoption of new tools.
-STAMPED provides a descriptive vocabulary and a framework for evaluation that can incrementally improve the operational properties of research objects towards enhanced rigor, reproducibility, reusability, and efficiency.
+STAMPED provides a descriptive vocabulary and a framework for evaluation that can incrementally improve the operational properties of research objects towards enhanced rigor, reproducibility, reusability, transparency, and efficiency.
 
 \begin{figure}[htbp]
 \centering
@@ -141,8 +141,8 @@ Tracking~(T), Modularity~(M), Portability~(P), and Distributability~(D) each add
 \end{itemize}
 
 Research data and code change constantly during a project, and each change compounds the difficulty of reconstructing any previous state, such as which version of a dataset was used for a particular analysis, what parameters were set, and what code produced a given figure.
-Tracking addresses two concerns: 1) the identity of each component and its exact state at a point in time, and 2) \textbf{provenance}, the recorded history of what actions by which identities produced or modified it.
-These are often managed separately, which makes prior work harder to validate.
+Tracking addresses two concerns: 1) the identity of each component and its exact state at a point in time, and 2) \textbf{provenance}, the recorded history of the actions by which identities produced or modified it.
+These are often managed separately, which makes reproducing and validating past work harder.
 
 The spectrum of Tracking begins with content-addressed version control.
 Rather than relying on semantic version labels, content-addressed systems identify each state by a checksum of its contents.
@@ -155,12 +155,12 @@ Traditional version control is designed for code and other text files, but resea
 Compatible tools such as git-annex, DataLad\cite{halchenko_datalad_2021}, or DVC\cite{ruslan_kuprieiev_dvc_2026} extend content-addressed tracking to these components, ensuring that all parts of the research object are managed under the same system.
 
 Toward the ideal end, provenance is captured programmatically by tooling rather than by manual annotation.
-Each computational step should record exactly what command was executed and what inputs were consumed, producing richer and more reliable records than a human would typically write.
+Each computational step should be recorded in terms of exactly what command was executed and what inputs were consumed, producing richer and more reliable records than a human would typically write.
 When modules are independently tracked under compatible systems, the version of every module at the time of each commit is also discoverable, providing a complete picture of the state that produced a given result.
 This enables not just inspection but re-execution.
 Beyond the research object itself, knowing the state of data and code at each hand-off between experimental, analytical, and engineering stages is what allows a team to coordinate updates without losing the provenance chain---an operational view of Tracking developed by the SciOps framework\cite{johnson_sciops_2024}.
 Across communities, multiple ontologies and packaging standards have emerged to make these provenance records portable across tools, including cross-domain models such as W3C~PROV\cite{w3c_provenance_working_group_prov-overview_2013}, packaging formats such as RO-Crate\cite{peroni_packaging_2022}, and domain-specific specifications such as BIDS-Prov (BEP028)\cite{bids_community_bep028_2025}.
-The relationships among such provenance, assertion, and evidence ontologies have been surveyed recently\cite{chhetri_bridging_2025}, emphasing already available reach ecosystem to be promoted and wider adopted for improving Tracking of scentific results.
+The relationships among such provenance, assertion, and evidence ontologies have been surveyed recently\cite{chhetri_bridging_2025}, emphasizing the already available rich ecosystem to be promoted and wider adopted for improving Tracking of scientific processes.
 
 
 \anchoredsubsection{actionability}{Actionability}
@@ -365,7 +365,7 @@ No single tool addresses all the dimensions of scientific rigor described above,
 For example, container technologies such as Docker or Singularity serve Portability by providing OS-level isolation from explicit environment specifications, enable Ephemerality~(E) by disposing per-execution environments, and facilitate Distributability~(D) by producing frozen, shareable artifacts.
 Similarly, version control systems such as Git underpin both Tracking (content-addressed identification and change history) and Self-containment (gathering all components under a single root).
 
-In practice, Self-containing~(S) all data might be undesired or prohibitive due to size or other concerns.
+In practice, Self-containing~(S) all data by storing it directly within the research object may be undesired or prohibitive due to size, licensing, or privacy concerns, creating a tension with Tracking~(T), which requires that every component be identified and versioned.
 Extensions such as git-annex, DataLad, DVC, and Git LFS strike the balance between the two principles by tracking metadata that identifies specific data versions and obtainability information instead, e.g., content checksums and URLs of remote servers that act as a source, and providing Actionable~(A) interfaces to obtain the data when necessary.
 
 This overlap is not incidental --- it reflects the interdependence of the STAMPED principles themselves.
@@ -443,7 +443,7 @@ The pages tagged ``STAMPED-intro'' (\httpsurl{examples.stamped-principles.org/ta
 Several research projects have already adopted and documented the YODA principles (the predecessor to STAMPED) demonstrating practical utility across domains.
 
 \textbf{BIDS Standard Evolution}: A significant validation of the ``do not look up'' principle occurred within the Brain Imaging Data Structure (BIDS)\cite{gorgolewski_brain_2016} community.
-Originally, the BIDS specification nested derived data under \texttt{derivatives/} within the original raw dataset, creating upward dependencies that violated Portability~(P).
+Originally, the BIDS specification nested derived data under \texttt{derivatives/} within the original raw dataset, creating upward dependencies that violated Modularity~(M) and, as a consequence, Portability~(P).
 Following YODA principles, the BIDS community reversed this relationship so that derivative datasets now exist independently and reference raw data as subdatasets, not vice versa.
 
 This architectural shift influenced major neuroimaging tools:


### PR DESCRIPTION
## Summary

Text improvements from a review of the manuscript, organized into separate commits for independent discussion. Each commit has a corresponding issue with detailed rationale.

- **Commit 1** (closes #169): Fix wording, typos, and unclear formulations across the manuscript — provenance definition at first use, grammar fixes, typo corrections, explicit S–T tension, BIDS Modularity addition
- **Commit 2** (closes #170): Tighten Table 1 descriptions for precision and active voice — see issue for before/after comparison
- **Commit 3** (closes #171): Add roadmap paragraph to introduction, rename "Comments" → "The STAMPED Principles", improve RFC 2119 transition
- **Commit 4** (closes #172): Add motivation sentences for Tracking and Modularity following the established pattern, reorder T requirements (MUSTs before SHOULDs), fix S foundation enumeration
- **Commit 5** (closes #173): Fix outdated CLAUDE.md link in README
- **Commit 6** (closes #174): Fix Table 2 Ephemeral/Portability overlap and Distributable redundancy

## Test plan

- [ ] Verify LaTeX builds without errors
- [ ] Review each commit independently — authors can request changes per issue
- [ ] Check that section/table references resolve correctly after rename