### PR TITLE
Clarify controlled access within modularity and distributability

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -298,7 +298,8 @@ Researchers routinely begin by downloading containers, fetching published datase
 Though persistent retrievability is a necessary but not sufficient condition for redistribution.
 Additionally, each module should carry an easily identifiable license or set of licenses for any bundled assets (e.g., via SPDX identifiers\cite{stewart_software_2010} or the REUSE specification\cite{fsfe_reuse_2024}) so that downstream researchers can compose, modify, and re-share components without legal ambiguity.
 
-The spectrum of Distributability~(D) intersects with FAIR Accessibility: whether access is public or restricted, STAMPED addresses operational aspects of distribution, such as persistent packaging and documented retrieval.
+Distributability~(D) intersects with FAIR Accessibility, which establishes that an identified component can be retrieved through a documented protocol, including authentication or authorization where required.
+Distributability extends this concern to the research object as a whole: its referenced components remain obtainable in their intended versions as a coherent distribution.
 Toward the ideal end, several complementary strategies reduce the risk that external changes will break a research object's reproducibility.
 Bundling dependencies into containers or archives reduces the surface area of components that can independently change or disappear; hosting on archival infrastructure (Zenodo, DANDI, Software Heritage) with content-addressed identifiers allows recipients to verify integrity regardless of source; mirroring across multiple platforms protects against the failure of any single registry.
 Where downstream consumers must verify not only integrity but also origin and build process, signed releases and supply-chain attestations (e.g., sigstore, in-toto, SLSA) provide cryptographic evidence that an artifact was produced by the claimed identity from the claimed sources.

--- a/main.tex
+++ b/main.tex
@@ -220,8 +220,8 @@ In practice, module boundaries often align with repository boundaries, but a mod
 Modularity applies this principle to research objects, structuring them as assemblies of modules whose boundaries are explicit.
 Module boundaries are also where license compatibility must be checked, since combining modules with incompatible terms can prevent the assembled research object from being lawfully redistributed.
 In addition to licenses, data use agreements and other legal, ethical, institutional, or technical constraints may impose different conditions on access and redistribution across a research object.
-For example, ABCD Study data are available to approved researchers under a Data Use Certification but not for unrestricted redistribution, even when organized to be technically distributable.
-These conditions may be managed through separate modules or permissions on individual files or objects, depending on which is most practical.
+For example, the U.S. Census Bureau releases disclosure-protected public-use data while reserving detailed microdata for secure research environments \citep{united_states_census_bureau_dissemination_2025}; GBIF guidance similarly recommends publishing generalized species locations while providing precise coordinates only under agreement \citep{chapman_current_2020}.
+These conditions may be managed through separate modules, alternate representations, or permissions on individual files or objects, depending on the access-control mechanisms supported by the underlying technologies.
 Accounting for them during design is consistent with FAIR Accessibility, which accommodates controlled access.
 
 At a minimum, a research object should separate analysis code, input datasets, computational environments, licenses, configuration settings, and results into distinct directories.
@@ -297,7 +297,7 @@ Researchers routinely begin by downloading containers, fetching published datase
 Though persistent retrievability is a necessary but not sufficient condition for redistribution.
 Additionally, each module should carry an easily identifiable license or set of licenses for any bundled assets (e.g., via SPDX identifiers\cite{stewart_software_2010} or the REUSE specification\cite{fsfe_reuse_2024}) so that downstream researchers can compose, modify, and re-share components without legal ambiguity.
 
-The spectrum of distributability intersects with FAIR Accessibility: components may be publicly retrievable or subject to authentication and authorization, while STAMPED additionally asks whether they are packaged and maintained in a persistent state that can be distributed when permission allows.
+The spectrum of Distributability~(D) intersects with FAIR Accessibility: whether access is public or restricted, STAMPED addresses operational aspects of distribution, such as persistent packaging and documented retrieval.
 Toward the ideal end, several complementary strategies reduce the risk that external changes will break a research object's reproducibility.
 Bundling dependencies into containers or archives reduces the surface area of components that can independently change or disappear; hosting on archival infrastructure (Zenodo, DANDI, Software Heritage) with content-addressed identifiers allows recipients to verify integrity regardless of source; mirroring across multiple platforms protects against the failure of any single registry.
 Where downstream consumers must verify not only integrity but also origin and build process, signed releases and supply-chain attestations (e.g., sigstore, in-toto, SLSA) provide cryptographic evidence that an artifact was produced by the claimed identity from the claimed sources.

--- a/main.tex
+++ b/main.tex
@@ -219,6 +219,10 @@ This can include a subdataset, a collection of analysis scripts, or the definiti
 In practice, module boundaries often align with repository boundaries, but a module may also be a published container, a registered dataset, or any independently versioned unit.
 Modularity applies this principle to research objects, structuring them as assemblies of modules whose boundaries are explicit.
 Module boundaries are also where license compatibility must be checked, since combining modules with incompatible terms can prevent the assembled research object from being lawfully redistributed.
+In addition to licenses, data use agreements and other legal, ethical, institutional, or technical constraints may impose different conditions on access and redistribution across a research object.
+For example, ABCD Study data are available to approved researchers under a Data Use Certification but not for unrestricted redistribution, even when organized to be technically distributable.
+These conditions may be managed through separate modules or permissions on individual files or objects, depending on which is most practical.
+Accounting for them during design is consistent with FAIR Accessibility, which accommodates controlled access.
 
 At a minimum, a research object should separate analysis code, input datasets, computational environments, licenses, configuration settings, and results into distinct directories.
 Beyond this, independent versioning of modules enables reuse; a dataset or environment can be updated to a newer version, or swapped for an alternative, without disrupting the rest of the research object.
@@ -293,7 +297,7 @@ Researchers routinely begin by downloading containers, fetching published datase
 Though persistent retrievability is a necessary but not sufficient condition for redistribution.
 Additionally, each module should carry an easily identifiable license or set of licenses for any bundled assets (e.g., via SPDX identifiers\cite{stewart_software_2010} or the REUSE specification\cite{fsfe_reuse_2024}) so that downstream researchers can compose, modify, and re-share components without legal ambiguity.
 
-The spectrum of distributability begins where FAIR leaves off, with publicly accessible components and documented retrieval instructions.
+The spectrum of distributability intersects with FAIR Accessibility: components may be publicly retrievable or subject to authentication and authorization, while STAMPED additionally asks whether they are packaged and maintained in a persistent state that can be distributed when permission allows.
 Toward the ideal end, several complementary strategies reduce the risk that external changes will break a research object's reproducibility.
 Bundling dependencies into containers or archives reduces the surface area of components that can independently change or disappear; hosting on archival infrastructure (Zenodo, DANDI, Software Heritage) with content-addressed identifiers allows recipients to verify integrity regardless of source; mirroring across multiple platforms protects against the failure of any single registry.
 Where downstream consumers must verify not only integrity but also origin and build process, signed releases and supply-chain attestations (e.g., sigstore, in-toto, SLSA) provide cryptographic evidence that an artifact was produced by the claimed identity from the claimed sources.

--- a/main.tex
+++ b/main.tex
@@ -209,6 +209,7 @@ A SciOps-style workflow makes hand-offs between experimental, analytical, and en
     \item \textbf{M.1}: Components SHOULD be organized in a modular structure.
     \item \textbf{M.2}: Components MAY be included directly or linked as subdatasets.
     \item \textbf{M.3}: Each module's license SHOULD be declared independently and checked for compatibility at the boundaries where modules are combined
+    \item \textbf{M.4}: Components governed by different access requirements SHOULD be isolated in separate modules where practical.
 \end{itemize}
 
 A research object may be Self-contained~(S) and Tracked~(T), yet when all components are interleaved in a single monolithic directory, it can be fragile and difficult to navigate.
@@ -221,7 +222,7 @@ Modularity applies this principle to research objects, structuring them as assem
 Module boundaries are also where license compatibility must be checked, since combining modules with incompatible terms can prevent the assembled research object from being lawfully redistributed.
 In addition to licenses, data use agreements and other legal, ethical, institutional, or technical constraints may impose different conditions on access and redistribution across a research object.
 For example, the U.S. Census Bureau releases disclosure-protected public-use data while reserving detailed microdata for secure research environments \citep{united_states_census_bureau_dissemination_2025}; GBIF guidance similarly recommends publishing generalized species locations while providing precise coordinates only under agreement \citep{chapman_current_2020}.
-These conditions may be managed through separate modules, alternate representations, or permissions on individual files or objects, depending on the access-control mechanisms supported by the underlying technologies.
+These conditions can be managed through separate modules, including privacy-preserving derivatives.
 Accounting for them during design is consistent with FAIR Accessibility, which accommodates controlled access.
 
 At a minimum, a research object should separate analysis code, input datasets, computational environments, licenses, configuration settings, and results into distinct directories.

--- a/references.bib
+++ b/references.bib
@@ -1,4 +1,7 @@
 
+@misc{noauthor_notitle_nodate,
+}
+
 @article{haxby_common_2011,
 	title = {A {Common}, {High}-{Dimensional} {Model} of the {Representational} {Space} in {Human} {Ventral} {Temporal} {Cortex}},
 	volume = {72},
@@ -64,7 +67,6 @@
 	author = {Guntupalli, J. Swaroop and Hanke, Michael and Halchenko, Yaroslav O. and Connolly, Andrew C. and Ramadge, Peter J. and Haxby, James V.},
 	month = jun,
 	year = {2016},
-	pmid = {26980615},
 	pages = {2919--2934},
 }
 
@@ -256,7 +258,6 @@
 	author = {Timchenko, L. I. and Kutaev, Y. F. and Gertsiy, A. A. and Zahoruiko, L. V. and Halchenko, Y. O. and Mansur, T.},
 	editor = {Miller, J. W. V. and Solomon, S. S. and Batchelor, B. G.},
 	year = {1999},
-	note = {event-place: Boston, MA, USA},
 	pages = {71--81},
 }
 
@@ -460,16 +461,20 @@ Tweet \#BioCompute @BioComputeObj},
 }
 
 @inproceedings{chhetri_bridging_2025,
-	address = {Sydney, NSW, Australia},
+	address = {Sydney NSW Australia},
 	title = {Bridging the {Scientific} {Knowledge} {Gap} and {Reproducibility}: {A} {Survey} of {Provenance}, {Assertion} and {Evidence} {Ontologies}},
-	isbn = {979-8-4007-1331-6/25/04},
+	isbn = {979-8-4007-1331-6},
+	shorttitle = {Bridging the {Scientific} {Knowledge} {Gap} and {Reproducibility}},
+	url = {https://dl.acm.org/doi/10.1145/3701716.3715483},
 	doi = {10.1145/3701716.3715483},
-	booktitle = {Companion {Proceedings} of the {ACM} {Web} {Conference} 2025 (to appear)},
+	language = {en},
+	urldate = {2026-05-19},
+	booktitle = {Companion {Proceedings} of the {ACM} on {Web} {Conference} 2025},
 	publisher = {ACM},
-	author = {Chhetri, Tek Raj and Halchenko, Yaroslav O. and Jarecka, Dorota and Trivedi, Puja and Ghosh, Satrajit and Ray, Patrick and Ng, Lydia},
+	author = {Chhetri, Tek Raj and Halchenko, Yaroslav O. and Jarecka, Dorota and Trivedi, Puja and Ghosh, Satrajit S. and Ray, Patrick and Ng, Lydia},
 	month = may,
 	year = {2025},
-	note = {event-place: Sydney, NSW, Australia},
+	pages = {924--928},
 }
 
 @inproceedings{chhetri_bridging_2025-1,
@@ -490,20 +495,16 @@ Tweet \#BioCompute @BioComputeObj},
 }
 
 @inproceedings{chhetri_bridging_2025-2,
-	address = {Sydney NSW Australia},
+	address = {Sydney, NSW, Australia},
 	title = {Bridging the {Scientific} {Knowledge} {Gap} and {Reproducibility}: {A} {Survey} of {Provenance}, {Assertion} and {Evidence} {Ontologies}},
 	isbn = {979-8-4007-1331-6},
-	shorttitle = {Bridging the {Scientific} {Knowledge} {Gap} and {Reproducibility}},
-	url = {https://dl.acm.org/doi/10.1145/3701716.3715483},
+	url = {https://doi.org/10.1145/3701716.3715483},
 	doi = {10.1145/3701716.3715483},
-	language = {en},
-	urldate = {2026-05-19},
-	booktitle = {Companion {Proceedings} of the {ACM} on {Web} {Conference} 2025},
+	booktitle = {Companion {Proceedings} of the {ACM} {Web} {Conference} 2025 (to appear)},
 	publisher = {ACM},
-	author = {Chhetri, Tek Raj and Halchenko, Yaroslav O. and Jarecka, Dorota and Trivedi, Puja and Ghosh, Satrajit S. and Ray, Patrick and Ng, Lydia},
+	author = {Chhetri, Tek Raj and Halchenko, Yaroslav O. and Jarecka, Dorota and Trivedi, Puja and Ghosh, Satrajit and Ray, Patrick and Ng, Lydia},
 	month = may,
 	year = {2025},
-	pages = {924--928},
 }
 
 @misc{nastase_clustering_2015,
@@ -540,14 +541,24 @@ Tweet \#BioCompute @BioComputeObj},
 	pages = {1--4},
 }
 
+@article{chapman_current_2020,
+	title = {Current {Best} {Practices} for {Generalizing} {Sensitive} {Species} {Occurrence} {Data}},
+	url = {https://docs.gbif.org/sensitive-species-best-practices/master/en/},
+	doi = {10.15468/DOC-5JP4-5G10},
+	abstract = {This document aims to provide best practice (or best current practice) for dealing with sensitive primary species occurrence data, and provide guidance on how to make as much data available without at the same time opening up the species to harm because data has been placed in the public domain.},
+	urldate = {2026-07-30},
+	author = {Chapman, Arthur},
+	year = {2020},
+}
+
 @misc{halchenko_dartmouth_2023,
 	title = {Dartmouth {Brain} {Imaging} {Center} ({DBIC}) {QA} data (weekly {QA} scans etc.)},
 	copyright = {Open Data Commons Public Domain Dedication \& License 1.0},
 	url = {https://zenodo.org/record/8253053},
+	doi = {10.5281/ZENODO.8253053},
 	publisher = {Zenodo},
 	author = {Halchenko, Yaroslav O. and Kodiweera, Chandana and Sacket, Terry},
 	year = {2023},
-	doi = {10.5281/ZENODO.8253053},
 }
 
 @misc{elixir_rdmkit_community_data_2024,
@@ -686,6 +697,17 @@ Tweet \#BioCompute @BioComputeObj},
 	journal = {Scientific Data},
 	author = {Rorden, Christopher and Béranger, Benoît and Cheng, Hu and Clemence, Matthew and Debacker, Clément and Fernandez, Brice and Halchenko, Yaroslav O. and Harms, Michael P. and Holla, Bharath and Innis, Isaiah and Kuijer, Joost P. A. and Levitas, Daniel and Litinas, Krisanne and Luci, Jeffrey and Newman-Norlund, Roger and Peltier, Scott and Rehwald, Wolfgang and Reid, Robert I. and Rogers, Baxter and Schwarz, Christopher G. and Shin, Jaemin and Ganesan, Venkatasubramanian and Ganji, Sandeep and Morgan, Paul S.},
 	month = jul,
+	year = {2025},
+}
+
+@misc{united_states_census_bureau_dissemination_2025,
+	title = {Dissemination and {Access}—{Innovation} and {Research}},
+	url = {https://www.census.gov/topics/research/dissemination-access.html},
+	language = {en-US},
+	urldate = {2026-07-30},
+	journal = {United States Census Bureau},
+	author = {{United States Census Bureau}},
+	month = jan,
 	year = {2025},
 }
 
@@ -894,25 +916,14 @@ Full Changelog: https://github.com/treeverse/dvc/compare/3.67.0...3.67.1},
 	keywords = {EEG, fMRI, fusion},
 }
 
-@article{halchenko_fusion_2004-1,
-	title = {Fusion of functional brain imaging modalities via linear programming},
-	volume = {48},
-	url = {http://www.onerussian.com/Sci/pubs/lpnfsi2003.pdf},
-	number = {2},
-	journal = {Biomedizinische Technik (Biomedical Engineering)},
-	author = {Halchenko, Y. O. and Pearlmutter, B. A. and Hanson, S. J. and Zaimi, A.},
-	year = {2004},
-	pages = {102--4},
-}
-
 @misc{taylor_go_2025,
 	title = {Go {Figure}: {Transparency} in neuroscience images preserves context and clarifies interpretation},
 	copyright = {Creative Commons Attribution 4.0 International},
 	url = {https://arxiv.org/abs/2504.07824},
+	doi = {10.48550/ARXIV.2504.07824},
 	publisher = {arXiv},
 	author = {Taylor, Paul A. and Aggarwal, Himanshu and Bandettini, Peter and Barilari, Marco and Bright, Molly and Caballero-Gaudes, Cesar and Calhoun, Vince and Chakravarty, Mallar and Devenyi, Gabriel and Evans, Jennifer and Garza-Villarreal, Eduardo and Rasgado-Toledo, Jalil and Gau, Remi and Glen, Daniel and Goebel, Rainer and Gonzalez-Castillo, Javier and Gulban, Omer Faruk and Halchenko, Yaroslav and Handwerker, Daniel and Hanayik, Taylor and Lauren, Peter and Leopold, David and Lerch, Jason and Mathys, Christian and McCarthy, Paul and McLeod, Anke and Mejia, Amanda and Moia, Stefano and Nichols, Thomas and Pernet, Cyril and Pessoa, Luiz and Pfleiderer, Bettina and Rajendra, Justin and Reyes, Laura and Reynolds, Richard and Roopchansingh, Vinai and Rorden, Chris and Russ, Brian and Sundermann, Benedikt and Thirion, Bertrand and Torrisi, Salvatore and Chen, Gang},
 	year = {2025},
-	doi = {10.48550/ARXIV.2504.07824},
 	keywords = {FOS: Biological sciences, Neurons and Cognition (q-bio.NC)},
 }
 
@@ -1118,6 +1129,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 @techreport{bradner_key_1997,
 	title = {Key words for use in {RFCs} to {Indicate} {Requirement} {Levels}},
 	url = {https://www.rfc-editor.org/info/rfc2119},
+	doi = {10.17487/rfc2119},
 	language = {en},
 	number = {RFC2119},
 	urldate = {2026-03-06},
@@ -1125,7 +1137,6 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	author = {Bradner, S.},
 	month = mar,
 	year = {1997},
-	doi = {10.17487/rfc2119},
 	pages = {RFC2119},
 }
 
@@ -1168,7 +1179,6 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	author = {Timchenko, L. I. and Kutaev, Y. F. and Gertsiy, A. A. and Halchenko, Y. O. and Zahoruiko, L. V. and Mansur, T.},
 	editor = {Gurevich, S. B. and Nazarchuk, Z. T. and Muravsky, L. I.},
 	year = {2000},
-	note = {event-place: Lviv, Ukraine},
 	pages = {19--26},
 }
 
@@ -1835,6 +1845,7 @@ Full Changelog: https://github.com/stamped-principles/stamped-examples/commits/0
 	copyright = {Creative Commons Attribution 4.0 International},
 	shorttitle = {stamped-principles/stamped-principles-schema},
 	url = {https://zenodo.org/doi/10.5281/zenodo.19672387},
+	doi = {10.5281/ZENODO.19672387},
 	abstract = {v0.1.0
 
 First alpha release of the STAMPED principles schema.},
@@ -1843,7 +1854,6 @@ First alpha release of the STAMPED principles schema.},
 	author = {{Cody Baker}},
 	month = apr,
 	year = {2026},
-	doi = {10.5281/ZENODO.19672387},
 }
 
 @article{gentleman_statistical_2007,
@@ -2007,7 +2017,6 @@ First alpha release of the STAMPED principles schema.},
 	journal = {Journal of Cognitive Neuroscience},
 	author = {Sha, Long and Haxby, James V. and Abdi, Hervé and Guntupalli, J. Swaroop and Oosterhof, Nikolaas N. and Halchenko, Yaroslav O. and Connolly, Andrew C.},
 	year = {2015},
-	pmid = {25269114},
 	pages = {665--678},
 }
 
@@ -2021,11 +2030,11 @@ First alpha release of the STAMPED principles schema.},
 @misc{gorgolewski_brain_2020,
 	title = {The {Brain} {Imaging} {Data} {Structure} ({BIDS}) {Specification}, {Version} 1.3.0},
 	url = {https://doi.org/10.5281/zenodo.3720628},
+	doi = {10.5281/zenodo.3720628},
 	publisher = {Zenodo},
 	author = {Gorgolewski, Kzrysztof J and Poline, Jean-Baptiste and Keator, David B and Nichols, B Nolan and Auer, Tibor and Craddock, R Cameron and Flandin, Guillaume and Ghosh, Satrajit S and Sochat, Vanessa V and Rokem, Ariel and Halchenko, Yaroslav O and Hanke, Michael and Haselgrove, Christian and Helmer, Karl and Maumet, Camille and Nichols, Thomas E and Turner, Jessica A and Das, Samir and Kennedy, David N and Poldrack, Russell A},
 	month = apr,
 	year = {2020},
-	doi = {10.5281/zenodo.3720628},
 }
 
 @article{gorgolewski_brain_2016,
@@ -2183,6 +2192,20 @@ First alpha release of the STAMPED principles schema.},
 	journal = {bioRxiv},
 	author = {Visconti di Oleggio Castello, Matteo and Halchenko, Yaroslav O. and Guntupalli, J. Swaroop and Gors, Jason D. and Gobbini, Maria Ida},
 	year = {2017},
+}
+
+@article{rubel_neurodata_2022,
+	title = {The {Neurodata} {Without} {Borders} ecosystem for neurophysiological data science},
+	volume = {11},
+	copyright = {CC BY 4.0},
+	url = {https://elifesciences.org/articles/78362},
+	doi = {10.7554/eLife.78362},
+	language = {en},
+	journal = {eLife},
+	author = {Rübel, Oliver and Tritt, Andrew and Ly, Ryan and Dichter, Benjamin K and Ghosh, Satrajit and Niu, Lawrence and Baker, Pamela and Soltesz, Ivan and Ng, Lydia and Svoboda, Karel and Frank, Loren and Bouchard, Kristofer E},
+	month = oct,
+	year = {2022},
+	pages = {e78362},
 }
 
 @article{bannier_open_2021,

--- a/references.bib
+++ b/references.bib
@@ -1,7 +1,4 @@
 
-@misc{noauthor_notitle_nodate,
-}
-
 @article{haxby_common_2011,
 	title = {A {Common}, {High}-{Dimensional} {Model} of the {Representational} {Space} in {Human} {Ventral} {Temporal} {Cortex}},
 	volume = {72},
@@ -67,6 +64,7 @@
 	author = {Guntupalli, J. Swaroop and Hanke, Michael and Halchenko, Yaroslav O. and Connolly, Andrew C. and Ramadge, Peter J. and Haxby, James V.},
 	month = jun,
 	year = {2016},
+	pmid = {26980615},
 	pages = {2919--2934},
 }
 
@@ -258,6 +256,7 @@
 	author = {Timchenko, L. I. and Kutaev, Y. F. and Gertsiy, A. A. and Zahoruiko, L. V. and Halchenko, Y. O. and Mansur, T.},
 	editor = {Miller, J. W. V. and Solomon, S. S. and Batchelor, B. G.},
 	year = {1999},
+	note = {event-place: Boston, MA, USA},
 	pages = {71--81},
 }
 
@@ -461,20 +460,16 @@ Tweet \#BioCompute @BioComputeObj},
 }
 
 @inproceedings{chhetri_bridging_2025,
-	address = {Sydney NSW Australia},
+	address = {Sydney, NSW, Australia},
 	title = {Bridging the {Scientific} {Knowledge} {Gap} and {Reproducibility}: {A} {Survey} of {Provenance}, {Assertion} and {Evidence} {Ontologies}},
-	isbn = {979-8-4007-1331-6},
-	shorttitle = {Bridging the {Scientific} {Knowledge} {Gap} and {Reproducibility}},
-	url = {https://dl.acm.org/doi/10.1145/3701716.3715483},
+	isbn = {979-8-4007-1331-6/25/04},
 	doi = {10.1145/3701716.3715483},
-	language = {en},
-	urldate = {2026-05-19},
-	booktitle = {Companion {Proceedings} of the {ACM} on {Web} {Conference} 2025},
+	booktitle = {Companion {Proceedings} of the {ACM} {Web} {Conference} 2025 (to appear)},
 	publisher = {ACM},
-	author = {Chhetri, Tek Raj and Halchenko, Yaroslav O. and Jarecka, Dorota and Trivedi, Puja and Ghosh, Satrajit S. and Ray, Patrick and Ng, Lydia},
+	author = {Chhetri, Tek Raj and Halchenko, Yaroslav O. and Jarecka, Dorota and Trivedi, Puja and Ghosh, Satrajit and Ray, Patrick and Ng, Lydia},
 	month = may,
 	year = {2025},
-	pages = {924--928},
+	note = {event-place: Sydney, NSW, Australia},
 }
 
 @inproceedings{chhetri_bridging_2025-1,
@@ -495,16 +490,20 @@ Tweet \#BioCompute @BioComputeObj},
 }
 
 @inproceedings{chhetri_bridging_2025-2,
-	address = {Sydney, NSW, Australia},
+	address = {Sydney NSW Australia},
 	title = {Bridging the {Scientific} {Knowledge} {Gap} and {Reproducibility}: {A} {Survey} of {Provenance}, {Assertion} and {Evidence} {Ontologies}},
 	isbn = {979-8-4007-1331-6},
-	url = {https://doi.org/10.1145/3701716.3715483},
+	shorttitle = {Bridging the {Scientific} {Knowledge} {Gap} and {Reproducibility}},
+	url = {https://dl.acm.org/doi/10.1145/3701716.3715483},
 	doi = {10.1145/3701716.3715483},
-	booktitle = {Companion {Proceedings} of the {ACM} {Web} {Conference} 2025 (to appear)},
+	language = {en},
+	urldate = {2026-05-19},
+	booktitle = {Companion {Proceedings} of the {ACM} on {Web} {Conference} 2025},
 	publisher = {ACM},
-	author = {Chhetri, Tek Raj and Halchenko, Yaroslav O. and Jarecka, Dorota and Trivedi, Puja and Ghosh, Satrajit and Ray, Patrick and Ng, Lydia},
+	author = {Chhetri, Tek Raj and Halchenko, Yaroslav O. and Jarecka, Dorota and Trivedi, Puja and Ghosh, Satrajit S. and Ray, Patrick and Ng, Lydia},
 	month = may,
 	year = {2025},
+	pages = {924--928},
 }
 
 @misc{nastase_clustering_2015,
@@ -555,10 +554,10 @@ Tweet \#BioCompute @BioComputeObj},
 	title = {Dartmouth {Brain} {Imaging} {Center} ({DBIC}) {QA} data (weekly {QA} scans etc.)},
 	copyright = {Open Data Commons Public Domain Dedication \& License 1.0},
 	url = {https://zenodo.org/record/8253053},
-	doi = {10.5281/ZENODO.8253053},
 	publisher = {Zenodo},
 	author = {Halchenko, Yaroslav O. and Kodiweera, Chandana and Sacket, Terry},
 	year = {2023},
+	doi = {10.5281/ZENODO.8253053},
 }
 
 @misc{elixir_rdmkit_community_data_2024,
@@ -916,14 +915,25 @@ Full Changelog: https://github.com/treeverse/dvc/compare/3.67.0...3.67.1},
 	keywords = {EEG, fMRI, fusion},
 }
 
+@article{halchenko_fusion_2004-1,
+	title = {Fusion of functional brain imaging modalities via linear programming},
+	volume = {48},
+	url = {http://www.onerussian.com/Sci/pubs/lpnfsi2003.pdf},
+	number = {2},
+	journal = {Biomedizinische Technik (Biomedical Engineering)},
+	author = {Halchenko, Y. O. and Pearlmutter, B. A. and Hanson, S. J. and Zaimi, A.},
+	year = {2004},
+	pages = {102--4},
+}
+
 @misc{taylor_go_2025,
 	title = {Go {Figure}: {Transparency} in neuroscience images preserves context and clarifies interpretation},
 	copyright = {Creative Commons Attribution 4.0 International},
 	url = {https://arxiv.org/abs/2504.07824},
-	doi = {10.48550/ARXIV.2504.07824},
 	publisher = {arXiv},
 	author = {Taylor, Paul A. and Aggarwal, Himanshu and Bandettini, Peter and Barilari, Marco and Bright, Molly and Caballero-Gaudes, Cesar and Calhoun, Vince and Chakravarty, Mallar and Devenyi, Gabriel and Evans, Jennifer and Garza-Villarreal, Eduardo and Rasgado-Toledo, Jalil and Gau, Remi and Glen, Daniel and Goebel, Rainer and Gonzalez-Castillo, Javier and Gulban, Omer Faruk and Halchenko, Yaroslav and Handwerker, Daniel and Hanayik, Taylor and Lauren, Peter and Leopold, David and Lerch, Jason and Mathys, Christian and McCarthy, Paul and McLeod, Anke and Mejia, Amanda and Moia, Stefano and Nichols, Thomas and Pernet, Cyril and Pessoa, Luiz and Pfleiderer, Bettina and Rajendra, Justin and Reyes, Laura and Reynolds, Richard and Roopchansingh, Vinai and Rorden, Chris and Russ, Brian and Sundermann, Benedikt and Thirion, Bertrand and Torrisi, Salvatore and Chen, Gang},
 	year = {2025},
+	doi = {10.48550/ARXIV.2504.07824},
 	keywords = {FOS: Biological sciences, Neurons and Cognition (q-bio.NC)},
 }
 
@@ -1129,7 +1139,6 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 @techreport{bradner_key_1997,
 	title = {Key words for use in {RFCs} to {Indicate} {Requirement} {Levels}},
 	url = {https://www.rfc-editor.org/info/rfc2119},
-	doi = {10.17487/rfc2119},
 	language = {en},
 	number = {RFC2119},
 	urldate = {2026-03-06},
@@ -1137,6 +1146,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	author = {Bradner, S.},
 	month = mar,
 	year = {1997},
+	doi = {10.17487/rfc2119},
 	pages = {RFC2119},
 }
 
@@ -1179,6 +1189,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	author = {Timchenko, L. I. and Kutaev, Y. F. and Gertsiy, A. A. and Halchenko, Y. O. and Zahoruiko, L. V. and Mansur, T.},
 	editor = {Gurevich, S. B. and Nazarchuk, Z. T. and Muravsky, L. I.},
 	year = {2000},
+	note = {event-place: Lviv, Ukraine},
 	pages = {19--26},
 }
 
@@ -1845,7 +1856,6 @@ Full Changelog: https://github.com/stamped-principles/stamped-examples/commits/0
 	copyright = {Creative Commons Attribution 4.0 International},
 	shorttitle = {stamped-principles/stamped-principles-schema},
 	url = {https://zenodo.org/doi/10.5281/zenodo.19672387},
-	doi = {10.5281/ZENODO.19672387},
 	abstract = {v0.1.0
 
 First alpha release of the STAMPED principles schema.},
@@ -1854,6 +1864,7 @@ First alpha release of the STAMPED principles schema.},
 	author = {{Cody Baker}},
 	month = apr,
 	year = {2026},
+	doi = {10.5281/ZENODO.19672387},
 }
 
 @article{gentleman_statistical_2007,
@@ -2017,6 +2028,7 @@ First alpha release of the STAMPED principles schema.},
 	journal = {Journal of Cognitive Neuroscience},
 	author = {Sha, Long and Haxby, James V. and Abdi, Hervé and Guntupalli, J. Swaroop and Oosterhof, Nikolaas N. and Halchenko, Yaroslav O. and Connolly, Andrew C.},
 	year = {2015},
+	pmid = {25269114},
 	pages = {665--678},
 }
 
@@ -2030,11 +2042,11 @@ First alpha release of the STAMPED principles schema.},
 @misc{gorgolewski_brain_2020,
 	title = {The {Brain} {Imaging} {Data} {Structure} ({BIDS}) {Specification}, {Version} 1.3.0},
 	url = {https://doi.org/10.5281/zenodo.3720628},
-	doi = {10.5281/zenodo.3720628},
 	publisher = {Zenodo},
 	author = {Gorgolewski, Kzrysztof J and Poline, Jean-Baptiste and Keator, David B and Nichols, B Nolan and Auer, Tibor and Craddock, R Cameron and Flandin, Guillaume and Ghosh, Satrajit S and Sochat, Vanessa V and Rokem, Ariel and Halchenko, Yaroslav O and Hanke, Michael and Haselgrove, Christian and Helmer, Karl and Maumet, Camille and Nichols, Thomas E and Turner, Jessica A and Das, Samir and Kennedy, David N and Poldrack, Russell A},
 	month = apr,
 	year = {2020},
+	doi = {10.5281/zenodo.3720628},
 }
 
 @article{gorgolewski_brain_2016,
@@ -2192,20 +2204,6 @@ First alpha release of the STAMPED principles schema.},
 	journal = {bioRxiv},
 	author = {Visconti di Oleggio Castello, Matteo and Halchenko, Yaroslav O. and Guntupalli, J. Swaroop and Gors, Jason D. and Gobbini, Maria Ida},
 	year = {2017},
-}
-
-@article{rubel_neurodata_2022,
-	title = {The {Neurodata} {Without} {Borders} ecosystem for neurophysiological data science},
-	volume = {11},
-	copyright = {CC BY 4.0},
-	url = {https://elifesciences.org/articles/78362},
-	doi = {10.7554/eLife.78362},
-	language = {en},
-	journal = {eLife},
-	author = {Rübel, Oliver and Tritt, Andrew and Ly, Ryan and Dichter, Benjamin K and Ghosh, Satrajit and Niu, Lawrence and Baker, Pamela and Soltesz, Ivan and Ng, Lydia and Svoboda, Karel and Frank, Loren and Bouchard, Kristofer E},
-	month = oct,
-	year = {2022},
-	pages = {e78362},
 }
 
 @article{bannier_open_2021,


### PR DESCRIPTION
## Summary

- explain how licenses, data use agreements, and other constraints can create different access and redistribution conditions across a research object
- use the ABCD Study as a controlled-access example without implying an outright prohibition on sharing
- clarify that FAIR Accessibility can include authentication and authorization while STAMPED additionally addresses persistent, distributable packaging

## Why

The manuscript previously framed distributability around publicly accessible components and did not explain how STAMPED applies to controlled datasets. The revision distinguishes technical distributability from permission to redistribute and shows how access conditions may be managed at module or object granularity.

## Impact

This makes the Modularity and Distributability sections more applicable to real-world research governed by legal, ethical, institutional, or technical access constraints, while preserving distributability as an aspirational principle.

## Validation

- built `main.pdf` successfully with `latexmk`
- confirmed no undefined citations or references
- confirmed no whitespace errors with `git diff --check`
