### PR TITLE
Migrate: citation keys to match updated output from zotero

### DIFF
--- a/code/migrate-citation-keys.py
+++ b/code/migrate-citation-keys.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+#
+# Migrate main.tex citation keys onto the keys Zotero now exports.
+#
+# Zotero's BibTeX export used to generate a citation key at export time from
+# author, title and year (snake_case).  It now returns each item's stored
+# citationKey field instead (camelCase), so regenerating references.bib renames
+# nearly every entry and the manuscript's \cite commands stop resolving.
+#
+# Citation keys are therefore not a stable way to say "this work".  The
+# migration is only verifiable against something that survives the rename:
+#
+#     DOI  ->  else URL  ->  else title
+#
+# Some cited entries carry no DOI (talks, specifications, repositories), which
+# is why the chain has fallbacks rather than requiring one.
+#
+# Run with no arguments to audit: parse both files, resolve every citation site
+# to an identity, and report.  Nothing is written.
+#
+# Run with --migrate to regenerate the bibliography, rewrite the keys, and
+# verify that every citation site still resolves to the identity it had before.
+# The verification is the point: "all keys resolve" would also pass if a
+# citation were repointed at a different work.
+#
+# Keys that vanish from the library entirely cannot be mapped and must be named
+# with --expect-missing; anything else disappearing is a hard failure.
+#
+# Where several library records share one DOI, the first candidate is taken
+# deterministically.  That is safe -- same DOI, same work -- but it means the
+# bibliography may render a less complete duplicate.  Deduplicating the library
+# is the real fix and removes the choice entirely.
+#
+# Usage:
+#   migrate-citation-keys.py
+#   migrate-citation-keys.py --migrate [--dry-run] [--expect-missing K1,K2]
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+from collections import Counter, defaultdict
+
+# Citation commands to scan for.  main.tex uses \cite, but a stray \citep or
+# \autocite must not be silently skipped -- a missed site is a missed rename.
+CITE_COMMANDS = (
+    "cite", "citep", "citet", "citeauthor", "citeyear",
+    "autocite", "parencite", "textcite", "footcite",
+)
+
+CITE_RE = re.compile(
+    r"\\(" + "|".join(CITE_COMMANDS) + r")\*?"   # command, optional star
+    r"(?:\[[^\]]*\])*"                            # optional [pre][post] args
+    r"\{([^}]*)\}"                                # the key list
+)
+
+ENTRY_RE = re.compile(r"^@(\w+)\s*\{\s*([^,\s]+)\s*,", re.MULTILINE)
+
+
+def parse_bib(text):
+    """Parse a .bib file into {key: {field: value}}.
+
+    Brace-aware: values may span lines and contain nested braces.  This also
+    means line-initial '@' inside an abstract (references.bib holds several
+    GitHub @-mentions) is correctly ignored, which a line-based scan gets wrong.
+    """
+    entries = {}
+    pos = 0
+    while True:
+        m = ENTRY_RE.search(text, pos)
+        if not m:
+            break
+        key = m.group(2)
+        body_start = text.index("{", m.start())
+        body_end = _match_brace(text, body_start)
+        if body_end is None:
+            sys.exit(f"unbalanced braces in entry {key!r}")
+        body = text[text.index(",", body_start) + 1 : body_end]
+        entries[key] = _parse_fields(body)
+        entries[key]["_type"] = m.group(1).lower()
+        pos = body_end + 1
+    return entries
+
+
+def _match_brace(text, start):
+    """Index of the '}' matching the '{' at start, or None."""
+    depth = 0
+    for i in range(start, len(text)):
+        c = text[i]
+        if c == "{" and (i == 0 or text[i - 1] != "\\"):
+            depth += 1
+        elif c == "}" and text[i - 1] != "\\":
+            depth -= 1
+            if depth == 0:
+                return i
+    return None
+
+
+def _parse_fields(body):
+    """Extract 'name = value' pairs from an entry body."""
+    fields = {}
+    i = 0
+    while i < len(body):
+        m = re.compile(r"\s*(\w+)\s*=\s*").match(body, i)
+        if not m:
+            i += 1
+            continue
+        name = m.group(1).lower()
+        j = m.end()
+        if j < len(body) and body[j] == "{":
+            end = _match_brace(body, j)
+            if end is None:
+                break
+            value, i = body[j + 1 : end], end + 1
+        elif j < len(body) and body[j] == '"':
+            end = body.index('"', j + 1)
+            value, i = body[j + 1 : end], end + 1
+        else:
+            end = body.find(",", j)
+            end = len(body) if end == -1 else end
+            value, i = body[j:end], end
+        fields[name] = value.strip()
+    return fields
+
+
+def norm_doi(v):
+    v = re.sub(r"^\s*(https?://(dx\.)?doi\.org/|doi:)", "", v.strip(), flags=re.I)
+    return re.sub(r"[{}\s]", "", v).lower()
+
+
+def norm_url(v):
+    v = re.sub(r"^\s*https?://", "", v.strip(), flags=re.I)
+    return re.sub(r"[{}\s]", "", v).rstrip("/").lower()
+
+
+def norm_title(v):
+    return re.sub(r"[^a-z0-9]", "", v.lower())
+
+
+def identity(entry):
+    """(kind, value) that survives a key rename, or None if unidentifiable."""
+    if entry.get("doi"):
+        return ("doi", norm_doi(entry["doi"]))
+    if entry.get("url"):
+        return ("url", norm_url(entry["url"]))
+    if entry.get("title"):
+        return ("title", norm_title(entry["title"]))
+    return None
+
+
+def find_sites(tex):
+    """Every cited key in document order: (n, key, command, label).
+
+    A site is one key occurrence, so \\cite{a,b} is two sites.  n is the
+    ordinal used as the migration's identity; label is for humans reading
+    the report and carries no meaning to the tool.
+    """
+    sites = []
+    for m in CITE_RE.finditer(tex):
+        command, keylist = m.group(1), m.group(2)
+        label = _preceding_words(tex, m.start())
+        for key in (k.strip() for k in keylist.split(",")):
+            if key:
+                sites.append((len(sites) + 1, key, command, label))
+    return sites
+
+
+def _preceding_words(tex, pos, count=5):
+    before = tex[max(0, pos - 400) : pos]
+    before = re.sub(r"\\[a-zA-Z]+\*?(\[[^\]]*\])*", " ", before)  # drop commands
+    before = re.sub(r"[{}$%~\\]", " ", before)
+    words = before.split()
+    return " ".join(words[-count:]) if words else "(start of document)"
+
+
+def site_identities(tex, entries):
+    """{site ordinal: (identity, key, label)} -- the thing that must not change."""
+    out = {}
+    for n, key, _, label in find_sites(tex):
+        entry = entries.get(key)
+        out[n] = (identity(entry) if entry else None, key, label)
+    return out
+
+
+def build_key_map(cited, old_entries, new_entries):
+    """old key -> new key, resolved by identity.  Also returns diagnostics."""
+    index = defaultdict(list)
+    for key, entry in new_entries.items():
+        ident = identity(entry)
+        if ident:
+            index[ident].append(key)
+
+    mapping, missing, ambiguous = {}, [], []
+    for key in cited:
+        candidates = sorted(index.get(identity(old_entries[key]), []))
+        if not candidates:
+            missing.append(key)
+        elif len(candidates) > 1:
+            # Candidates share an identity, so they are the same work and any
+            # choice is correct; they differ only in metadata completeness.
+            # Take the first deterministically and report it.  The real fix is
+            # deduplicating the library, after which this branch stops firing.
+            ambiguous.append((key, candidates))
+            mapping[key] = candidates[0]
+        else:
+            mapping[key] = candidates[0]
+    return mapping, missing, ambiguous
+
+
+def rewrite_tex(tex, mapping):
+    """Substitute keys inside citation commands only, preserving spacing.
+
+    Keys are replaced span by span rather than by rejoining the key list, so
+    the diff of a 59-key rename shows only the keys and no whitespace churn.
+    """
+    edits, renamed = [], 0
+    for m in CITE_RE.finditer(tex):
+        base, seg, cursor = m.start(2), m.group(2), 0
+        for part in seg.split(","):
+            stripped = part.strip()
+            if stripped:
+                start = base + cursor + part.index(stripped)
+                new_key = mapping.get(stripped, stripped)
+                if new_key != stripped:
+                    edits.append((start, start + len(stripped), new_key))
+                    renamed += 1
+            cursor += len(part) + 1  # +1 for the comma
+    out, last = [], 0
+    for start, end, new_key in edits:
+        out.append(tex[last:start])
+        out.append(new_key)
+        last = end
+    out.append(tex[last:])
+    return "".join(out), renamed
+
+
+def verify(before, after, allow_broken):
+    """Every site must still resolve to the identity it had before.
+
+    Stronger than 'all keys resolve': a key that resolved to the wrong
+    duplicate record would pass that check and fail this one.
+    """
+    problems = []
+    for n, (ident, key, label) in sorted(before.items()):
+        new_ident, new_key, _ = after.get(n, (None, None, None))
+        if key in allow_broken:
+            continue
+        if new_ident is None:
+            problems.append(f"site {n:3d}  {new_key}  no longer resolves  ...{label}")
+        elif new_ident != ident:
+            problems.append(
+                f"site {n:3d}  {key} -> {new_key}  identity changed "
+                f"{ident} -> {new_ident}  ...{label}"
+            )
+    if len(before) != len(after):
+        problems.append(f"site count changed: {len(before)} -> {len(after)}")
+    return problems
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--tex", default="main.tex")
+    ap.add_argument("--bib", default="references.bib")
+    ap.add_argument("--verbose", action="store_true", help="list every site")
+    ap.add_argument("--migrate", action="store_true",
+                    help="regenerate the bibliography and rewrite the keys")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="with --migrate: report the plan, write nothing")
+    ap.add_argument("--new-bib", metavar="PATH",
+                    help="use this file as the regenerated bibliography "
+                         "instead of fetching (for testing)")
+    # No --group here on purpose: the fetch script owns the group id and the
+    # output path, so it stays in exactly one place.  We invoke it bare.
+    ap.add_argument("--fetch-script", default="code/fetch-zotero-bib.sh")
+    ap.add_argument("--expect-missing", default="", metavar="K1,K2",
+                    help="cited keys allowed to vanish from the library; "
+                         "anything else missing is a hard failure")
+    args = ap.parse_args()
+
+    allow_broken = {k for k in args.expect_missing.split(",") if k}
+
+    with open(args.bib, encoding="utf-8") as f:
+        entries = parse_bib(f.read())
+    with open(args.tex, encoding="utf-8") as f:
+        tex = f.read()
+    sites = find_sites(tex)
+
+    print(f"bib entries parsed : {len(entries)}")
+    print(f"citation sites     : {len(sites)}")
+    print(f"distinct keys cited: {len({s[1] for s in sites})}")
+    print(f"commands seen      : {dict(Counter(s[2] for s in sites))}")
+
+    # A cited key with no entry cannot be migrated -- it has no identity.
+    undefined = sorted({key for _, key, _, _ in sites if key not in entries})
+    print(f"\nundefined (cited, not in bib): {len(undefined)}")
+    for key in undefined:
+        print(f"  {key}")
+
+    # Which link in the identity chain each cited key relies on.
+    ids, unidentifiable = {}, []
+    for key in sorted({s[1] for s in sites}):
+        if key not in entries:
+            continue
+        ident = identity(entries[key])
+        if ident is None:
+            unidentifiable.append(key)
+        else:
+            ids[key] = ident
+    print(f"\nidentity source: {dict(Counter(k for k, _ in ids.values()))}")
+    if unidentifiable:
+        print(f"UNIDENTIFIABLE (no doi, url or title): {len(unidentifiable)}")
+        for key in unidentifiable:
+            print(f"  {key}")
+
+    # Two cited keys sharing an identity would later collapse into one key.
+    collisions = defaultdict(list)
+    for key, ident in ids.items():
+        collisions[ident].append(key)
+    shared = {i: ks for i, ks in collisions.items() if len(ks) > 1}
+    print(f"\ncited keys sharing an identity: {len(shared)}")
+    for ident, keys in shared.items():
+        print(f"  {ident[0]}:{ident[1][:60]}")
+        for key in keys:
+            print(f"      {key}")
+
+    if args.verbose:
+        print("\nsites:")
+        for n, key, _, label in sites:
+            kind = ids.get(key, ("?", "unresolved"))[0]
+            print(f"  {n:3d}  {kind:5s}  {key:46s}  ...{label}")
+
+    ok = not undefined and not unidentifiable and not shared
+    print("\nAUDIT OK" if ok else "\nAUDIT FOUND PROBLEMS (see above)")
+    if not args.migrate:
+        return 0 if ok else 1
+    if not ok:
+        sys.exit("refusing to migrate: resolve the audit problems first")
+
+    # The snapshot must be taken before the bibliography is replaced -- it is
+    # the only record of what each citation site pointed at beforehand.
+    before = site_identities(tex, entries)
+
+    backup = None
+    if args.new_bib:
+        new_path = args.new_bib
+        print(f"\nusing supplied bibliography: {new_path} (bibliography not installed)")
+    else:
+        backup = args.bib + ".pre-migration"
+        shutil.copyfile(args.bib, backup)
+        print(f"\nregenerating via {args.fetch_script} (backup at {backup})")
+        subprocess.run(["bash", args.fetch_script], check=True)
+        new_path = args.bib
+    with open(new_path, encoding="utf-8") as f:
+        new_entries = parse_bib(f.read())
+    print(f"regenerated entries: {len(new_entries)}")
+
+    cited = sorted({s[1] for s in sites})
+    mapping, missing, ambiguous = build_key_map(cited, entries, new_entries)
+
+    unchanged = sorted(k for k, v in mapping.items() if k == v)
+    print(f"\nmapped: {len(mapping)}   unchanged: {len(unchanged)}")
+    for key in unchanged:
+        print(f"      {key}")
+
+    if ambiguous:
+        print(f"\nambiguous -- several entries share one identity: {len(ambiguous)}")
+        for key, candidates in ambiguous:
+            print(f"  {key}")
+            for cand in candidates:
+                print(f"      {'-> ' if mapping[key] == cand else '   '}{cand}")
+
+    print(f"\ngone from the library: {len(missing)}")
+    for key in missing:
+        print(f"      {key}")
+    unexpected = sorted(set(missing) - allow_broken)
+    if unexpected:
+        _restore(backup, args.bib)
+        sys.exit("refusing to migrate: unexpected keys vanished: "
+                 + ", ".join(unexpected))
+    stale = sorted(allow_broken - set(missing))
+    if stale:
+        print(f"note: --expect-missing names present keys: {', '.join(stale)}")
+
+    # Two old keys collapsing onto one new key would silently merge distinct
+    # citations -- the one failure mode the identity check cannot see.
+    collapsed = defaultdict(list)
+    for old_key, new_key in mapping.items():
+        collapsed[new_key].append(old_key)
+    merged = {n: o for n, o in collapsed.items() if len(o) > 1}
+    if merged:
+        for new_key, old_keys in merged.items():
+            print(f"  MERGE {new_key} <- {', '.join(sorted(old_keys))}")
+        _restore(backup, args.bib)
+        sys.exit("refusing to migrate: distinct citations would collapse")
+
+    new_tex, renamed = rewrite_tex(tex, mapping)
+    print(f"\ncitation sites rewritten: {renamed} of {len(sites)}")
+
+    problems = verify(before, site_identities(new_tex, new_entries), allow_broken)
+    if problems:
+        print("\nVERIFICATION FAILED:")
+        for problem in problems:
+            print("  " + problem)
+        _restore(backup, args.bib)
+        return 1
+    checked = sum(1 for _, (_, key, _) in before.items() if key not in allow_broken)
+    print(f"verification: {checked} sites keep their exact identity")
+
+    if args.dry_run:
+        _restore(backup, args.bib)
+        print("\nDRY RUN -- nothing written")
+        return 0
+
+    with open(args.tex, "w", encoding="utf-8") as f:
+        f.write(new_tex)
+    if backup:
+        os.remove(backup)
+    print(f"\nwrote {args.tex}" + ("" if args.new_bib else f" and {args.bib}"))
+    return 0
+
+
+def _restore(backup, bib):
+    """Put the original bibliography back after an abort or a dry run."""
+    if backup and os.path.exists(backup):
+        os.replace(backup, bib)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/main.tex
+++ b/main.tex
@@ -69,8 +69,8 @@ It is common for the components of a research object to be organized independent
 This separation undermines rigor, reproducibility, reusability, and efficiency.
 Even when its components are gathered in one place, a research object is often tightly coupled to specific software versions and environments which may be opaque to outside collaborators, making it difficult to reuse or redistribute.
 
-The FAIR principles\cite{wilkinson_fair_2016} and FAIR4RS guidelines\cite{barker_introducing_2022} provide structured guidance for making digital objects "Findable, Accessible, Interoperable, and Reusable".
-The Workflow Community Initiative (WCI-FW)\cite{wilkinson_applying_2025} mapped these principles onto computational workflows but explicitly chose not to define new ones, instead treating workflows as hybrid data \& software objects.
+The FAIR principles\cite{wilkinsonFAIRGuidingPrinciples2016} and FAIR4RS guidelines\cite{barkerIntroducingFAIRPrinciples2022} provide structured guidance for making digital objects "Findable, Accessible, Interoperable, and Reusable".
+The Workflow Community Initiative (WCI-FW)\cite{wilkinsonApplyingFAIRPrinciples2025} mapped these principles onto computational workflows but explicitly chose not to define new ones, instead treating workflows as hybrid data \& software objects.
 STAMPED addresses a complementary layer: the day-to-day practices that underpin re-execution, extension, and redistribution of a research object.
 Both the FAIR and STAMPED frameworks cover overlapping concerns.
 For example, persistent identifiers serve both Findability and Tracking but accent different aspects.
@@ -79,7 +79,7 @@ FAIR emphasizes discovery and interoperability across repositories, while STAMPE
 Many researchers already employ practices that address these operational properties, such as version control, containerized environments, structured project directories, and documented analysis steps.
 Yet the community lacks a shared vocabulary for referring to these ideas, evaluating how thoroughly they are applied, and communicating that evaluation to collaborators and reviewers.
 Here we provide that vocabulary by introducing seven principles which articulate how Self-contained, Tracked, Actionable, Modular, Portable, Ephemeral, and Distributable (STAMPED) a research object is, thus describing its operational maturity.
-These originate from both the YODA Principles\cite{hanke_yoda_2018}, as well as VAMP\cite{hanke_what_2023}.
+These originate from both the YODA Principles\cite{hankeYODAYODAsOrganigram2018}, as well as VAMP\cite{hankeWhatDataLadWhat2023}.
 Rather than a compliance threshold, each STAMPED principle is a spectrum from a practical minimum---often what researchers are already doing---to an aspirational ideal.
 A researcher who stores everything under one project directory, version-controls analysis scripts, and documents how to run them is already meeting the practical minimum for Self-containment, Tracking, and Actionability.
 As complexity grows, such as for multi-institutional collaborations with heterogeneous workflows spanning platforms enforcing long-term reproducibility, these same principles guide researchers toward more rigorous practices without requiring wholesale adoption of new tools.
@@ -116,7 +116,7 @@ D & Distributability & All modules and procedures are shareable externally in a 
 \end{tabular}
 \end{table}
 
-The formal requirements use the graded keywords of RFC~2119\cite{bradner_key_1997}: MUST defines the practical minimum, while SHOULD and MAY indicate progressively more aspirational practices.
+The formal requirements use the graded keywords of RFC~2119\cite{bradnerKeyWordsUse1997}: MUST defines the practical minimum, while SHOULD and MAY indicate progressively more aspirational practices.
 
 
 
@@ -165,15 +165,15 @@ This unifies identity and provenance in a single system and also provides a safe
 For tracking to be effective, all components of the research object must be under version control: code, data, environment definitions, and configuration.
 
 Traditional version control is designed for code and other text files, but research objects often include large binary datasets, container images, and other assets that do not fit this model.
-Compatible tools such as git-annex, DataLad\cite{halchenko_datalad_2021}, or DVC\cite{ruslan_kuprieiev_dvc_2026} extend content-addressed tracking to these components, ensuring that all parts of the research object are managed under the same system.
+Compatible tools such as git-annex, DataLad\cite{halchenkoDataLadDistributedSystem2021}, or DVC\cite{ruslankuprieievDVCDataVersion2026} extend content-addressed tracking to these components, ensuring that all parts of the research object are managed under the same system.
 
 Toward the ideal end, provenance is captured programmatically by tooling rather than by manual annotation.
 Each computational step should record exactly what command was executed and what inputs were consumed, producing richer and more reliable records than a human would typically write.
 When modules are independently tracked under compatible systems, the version of every module at the time of each commit is also discoverable, providing a complete picture of the state that produced a given result.
 This enables not just inspection but re-execution.
-Beyond the research object itself, knowing the state of data and code at each hand-off between experimental, analytical, and engineering stages is what allows a team to coordinate updates without losing the provenance chain---an operational view of tracking developed by the SciOps framework\cite{johnson_sciops_2024}.
-Across communities, multiple ontologies and packaging standards have emerged to make these provenance records portable across tools, including cross-domain models such as W3C~PROV\cite{w3c_provenance_working_group_prov-overview_2013}, packaging formats such as RO-Crate\cite{peroni_packaging_2022}, and domain-specific specifications such as BIDS-Prov (BEP028)\cite{bids_community_bep028_2025}.
-The relationships among such provenance, assertion, and evidence ontologies have been surveyed recently\cite{chhetri_bridging_2025}, emphasizing the already available rich ecosystem to be promoted and wider adopted for improving tracking of scientific processes.
+Beyond the research object itself, knowing the state of data and code at each hand-off between experimental, analytical, and engineering stages is what allows a team to coordinate updates without losing the provenance chain---an operational view of tracking developed by the SciOps framework\cite{johnsonSciOpsAchievingProductivity2024}.
+Across communities, multiple ontologies and packaging standards have emerged to make these provenance records portable across tools, including cross-domain models such as W3C~PROV\cite{w3cprovenanceworkinggroupPROVOverviewOverviewPROV2013}, packaging formats such as RO-Crate\cite{soiland-reyesPackagingResearchArtefacts2022}, and domain-specific specifications such as BIDS-Prov (BEP028)\cite{bidscommunityBEP028BIDSExtension2025}.
+The relationships among such provenance, assertion, and evidence ontologies have been surveyed recently\cite{chhetriBridgingScientificKnowledge2025}, emphasizing the already available rich ecosystem to be promoted and wider adopted for improving tracking of scientific processes.
 
 
 \anchoredsubsection{actionability}{Actionability}
@@ -199,7 +199,7 @@ At the ideal end, each principle is enacted not through documentation alone but 
 \end{itemize}
 The principle is tool-agnostic; any system that moves a property from documented to executable moves the research object further along the actionability spectrum.
 Actionability also extends from tooling to the operational layer of a research group.
-A SciOps-style workflow makes hand-offs between experimental, analytical, and engineering stages explicit so that artifacts move from one step to the next with unambiguous state transition\cite{johnson_sciops_2024}, an organizational counterpart to the per-component actionability described above.
+A SciOps-style workflow makes hand-offs between experimental, analytical, and engineering stages explicit so that artifacts move from one step to the next with unambiguous state transition\cite{johnsonSciOpsAchievingProductivity2024}, an organizational counterpart to the per-component actionability described above.
 
 
 
@@ -243,7 +243,7 @@ Portability requires making all host dependencies explicit, so that the research
 Some degree of coupling to the host is unavoidable, such as path naming restrictions (``C:/'' vs. ``/mnt''), resource limits (minimum CPU/RAM requirements), or platform-specific flags.
 The spectrum of portability begins with isolating this host-specific configuration from the rest of the research object, so that adapting to a new environment, however involved that may be, requires only changing the configuration.
 Beyond this, several complementary approaches reduce host coupling.
-Virtual machines provide full system-level isolation; container-based tools (Docker, Singularity/Apptainer) bundle OS-level environments; declarative package managers (Nix\cite{kowalewski_sustainable_2022}, Guix\cite{courtes_reproducible_2015}) specify environments that can be reconstructed from a definition.
+Virtual machines provide full system-level isolation; container-based tools (Docker, Singularity/Apptainer) bundle OS-level environments; declarative package managers (Nix\cite{kowalewskiSustainablePackagingQuantum2022}, Guix\cite{courtesReproducibleUserControlledSoftware2015}) specify environments that can be reconstructed from a definition.
 Toward the ideal end, the computational environment is fully specified and version-controlled within the research object, enabling it to be instantiated on any compatible system.
 
 
@@ -263,7 +263,7 @@ Ephemerality eliminates this problem by construction; a disposable environment b
 
 The spectrum of ephemerality ranges from manually setting up a fresh environment from the project's specification (which is usually sufficient to catch environment drift) to fully automated disposable environments created and destroyed per execution.
 At the ideal end, ephemeral computation also enables testing across different host systems, where same-host execution validates specification completeness and different-host execution validates that specifications are not coupled to a specific system.
-The FAIRly big workflow\cite{wagner_fairly_2022} and other approaches to using Distributed~(D) computing platforms such as SLURM or Code Ocean\cite{cheifet_promoting_2021} operationalize this ideal, treating each computation as an ephemeral work unit.
+The FAIRly big workflow\cite{wagnerFAIRlyBigFramework2022} and other approaches to using Distributed~(D) computing platforms such as SLURM or Code Ocean\cite{cheifetPromotingReproducibilityCode2021} operationalize this ideal, treating each computation as an ephemeral work unit.
 This approach easily enables horizontal scaling, as independent disposable instances can be parallelized across subjects, parameters, or datasets.
 
 Yet ephemeral computation does not validate everything.
@@ -457,7 +457,7 @@ Archive and persistently host frozen, versioned research objects and their compo
 \anchoredsubsubsection{pedagogical-examples}{Pedagogical examples}
 
 A comprehensive up-to-date review of existing tools is out of scope for this formalization paper and would quickly become outdated.
-To fill that niche, we initiated a satellite project \texttt{stamped-examples}\citep{yaroslav_halchenko_stamped-principlesstamped-examples_2026} with a website to describe tools and examples, and characterize them in terms of STAMPED and FAIR principles at the \httpsurl{examples.stamped-principles.org} website.
+To fill that niche, we initiated a satellite project \texttt{stamped-examples}\citep{yaroslavhalchenkoStampedprinciplesStampedexamplesPreprint2026} with a website to describe tools and examples, and characterize them in terms of STAMPED and FAIR principles at the \httpsurl{examples.stamped-principles.org} website.
 These complement the formal definitions and walk a reader through the STAMPED properties using concrete examples.
 The pages tagged ``STAMPED-intro'' (\httpsurl{examples.stamped-principles.org/tags/stamped-intro/}) trace how each property applies to the same simple research object, providing a gentle on-ramp before the real-world adoptions below.
 
@@ -465,21 +465,21 @@ The pages tagged ``STAMPED-intro'' (\httpsurl{examples.stamped-principles.org/ta
 
 Several research projects have already adopted and documented the YODA principles (the predecessor to STAMPED) demonstrating practical utility across domains.
 
-\textbf{BIDS Standard Evolution}: A significant validation of the ``do not look up'' principle occurred within the Brain Imaging Data Structure (BIDS)\cite{gorgolewski_brain_2016} community.
+\textbf{BIDS Standard Evolution}: A significant validation of the ``do not look up'' principle occurred within the Brain Imaging Data Structure (BIDS)\cite{gorgolewskiBrainImagingData2016a} community.
 Originally, the BIDS specification nested derived data under \texttt{derivatives/} within the original raw dataset, creating upward dependencies that violated Self-containment~(S) and Modularity~(M), which broke Portability~(P).
 Following YODA principles, the BIDS community reversed this relationship so that derivative datasets now exist independently and reference raw data as subdatasets, not vice versa.
 
 This architectural shift influenced major neuroimaging tools:
 \begin{itemize}
-    \item \textbf{fMRIPrep}\cite{esteban_analysis_2020}: Switched default output layout to follow YODA structure
+    \item \textbf{fMRIPrep}\cite{estebanAnalysisTaskbasedFunctional2020}: Switched default output layout to follow YODA structure
     % TODO: add GitHub issue reference for "yoda" layout proposal
-    \item \textbf{OpenNeuroDerivatives}\cite{markiewicz_openneuro_2021}: Entire derivative dataset collection now follows YODA organization, separating processed outputs from raw data dependencies
+    \item \textbf{OpenNeuroDerivatives}\cite{markiewiczOpenNeuroResourceSharing2021}: Entire derivative dataset collection now follows YODA organization, separating processed outputs from raw data dependencies
     \item \textbf{BIDS specification}: Updated to accommodate and recommend YODA-compliant layouts for derivative datasets
 \end{itemize}
 
 \textbf{Workflow Platforms}: Infrastructure projects implementing YODA at scale:
 \begin{itemize}
-    \item \textbf{BABS}\cite{zhao_reproducible_2024}: Platform implementing the ``FAIRly big workflow'' approach, demonstrating YODA principles for large-scale neuroimaging analyses with containerized pipelines and modular dataset composition
+    \item \textbf{BABS}\cite{zhaoReproducibleGeneralizableSoftware2024}: Platform implementing the ``FAIRly big workflow'' approach, demonstrating YODA principles for large-scale neuroimaging analyses with containerized pipelines and modular dataset composition
     \item \textbf{CRCNS.org}: Neuroscience data sharing platform providing YODA-structured templates and validation tools
 \end{itemize}
 
@@ -494,39 +494,39 @@ Independently, each converged on strikingly similar organizational responses.
 What follows is not a comprehensive review but a tracing of that convergence, organized chronologically, to show that the principles STAMPED formalizes reflect durable responses to recurring challenges.
 
 The earliest calls for reproducibility-as-organization appeared in the 1990s.
-Claerbout and Karrenbach\cite{claerbout_electronic_1992} demonstrated that coupling electronic documents with Makefiles could make geophysical analyses self-contained, tracked, and re-executable---anticipating Self-containment~(S), Tracking~(T), and Actionability~(A).
-Buckheit and Donoho\cite{bickel_wavelab_1995} extended this idea with WaveLab, a compendium packaging code, data, and figures so that ``an article \ldots{} is not the scholarship itself, \ldots{} the actual scholarship is the complete software development environment and the complete set of instructions which generated the figures''---touching Self-containment~(S), Actionability~(A), Portability~(P), and Distributability~(D).
-Gentleman and Temple~Lang\cite{gentleman_statistical_2007} formalized the research compendium concept, emphasizing modular packaging for reuse and redistribution---Self-containment~(S), Modularity~(M), Actionability~(A), and Distributability~(D).
-Noble\cite{noble_quick_2009} provided the first widely adopted project-organization guide for computational biology, offering concrete directory-structure conventions that addressed Self-containment~(S) and Modularity~(M).
+Claerbout and Karrenbach\cite{claerboutElectronicDocumentsGive1992} demonstrated that coupling electronic documents with Makefiles could make geophysical analyses self-contained, tracked, and re-executable---anticipating Self-containment~(S), Tracking~(T), and Actionability~(A).
+Buckheit and Donoho\cite{buckheitWaveLabReproducibleResearch1995} extended this idea with WaveLab, a compendium packaging code, data, and figures so that ``an article \ldots{} is not the scholarship itself, \ldots{} the actual scholarship is the complete software development environment and the complete set of instructions which generated the figures''---touching Self-containment~(S), Actionability~(A), Portability~(P), and Distributability~(D).
+Gentleman and Temple~Lang\cite{gentlemanStatisticalAnalysesReproducible2007} formalized the research compendium concept, emphasizing modular packaging for reuse and redistribution---Self-containment~(S), Modularity~(M), Actionability~(A), and Distributability~(D).
+Noble\cite{nobleQuickGuideOrganizing2009} provided the first widely adopted project-organization guide for computational biology, offering concrete directory-structure conventions that addressed Self-containment~(S) and Modularity~(M).
 
 A wave of normative frameworks followed in the 2010s.
-Stodden\cite{stodden_scientific_2010} articulated legal and social dimensions of sharing computational research, raising concerns central to Distributability~(D) and Tracking~(T).
-Sandve et~al.\cite{sandve_ten_2013} distilled ten rules for reproducible computation (track versions, record workflows, archive environments)---spanning Tracking~(T), Actionability~(A), and Self-containment~(S).
-The FAIR principles\cite{wilkinson_fair_2016} established findability, accessibility, interoperability, and reusability as community norms for digital objects, later extended to research software by FAIR4RS\cite{barker_introducing_2022} and to workflows by the Workflow Community Initiative\cite{wilkinson_applying_2025}.
-Wilson et~al.\cite{wilson_good_2017} codified ``Good Enough Practices'' that operationalized many of these ideals for working scientists---Actionability~(A), Tracking~(T), and Self-containment~(S).
-The YODA principles\cite{hanke_yoda_2018} combined these insights into organizational practices for research data management.
-De~Smedt et~al.\cite{de_smedt_fair_2020} articulated the notion of FAIR Digital Objects as ``actionable knowledge units,'' foregrounding Actionability~(A) as a first-class concern complementary to FAIR.
-Building on YODA and this emphasis on actionability, the VAMP formulation\cite{hanke_what_2023} (Versioned, Actionable, Modular, Portable) made Actionability~(A), Portability~(P), and Modularity~(M) explicit organizational requirements, and introduced Ephemerality~(E) as validation for Portability~(P)---directly prefiguring STAMPED.
-Notably, the WCI-FW framework\cite{wilkinson_applying_2025} extended FAIR to computational workflows but explicitly declined to define new principles, leaving the operational gap  that STAMPED fills (how a research object should be structured and managed).
+Stodden\cite{stoddenScientificMethodPractice2010} articulated legal and social dimensions of sharing computational research, raising concerns central to Distributability~(D) and Tracking~(T).
+Sandve et~al.\cite{sandveTenSimpleRules2013} distilled ten rules for reproducible computation (track versions, record workflows, archive environments)---spanning Tracking~(T), Actionability~(A), and Self-containment~(S).
+The FAIR principles\cite{wilkinsonFAIRGuidingPrinciples2016} established findability, accessibility, interoperability, and reusability as community norms for digital objects, later extended to research software by FAIR4RS\cite{barkerIntroducingFAIRPrinciples2022} and to workflows by the Workflow Community Initiative\cite{wilkinsonApplyingFAIRPrinciples2025}.
+Wilson et~al.\cite{wilsonGoodEnoughPractices2017} codified ``Good Enough Practices'' that operationalized many of these ideals for working scientists---Actionability~(A), Tracking~(T), and Self-containment~(S).
+The YODA principles\cite{hankeYODAYODAsOrganigram2018} combined these insights into organizational practices for research data management.
+De~Smedt et~al.\cite{desmedtFAIRDigitalObjects2020} articulated the notion of FAIR Digital Objects as ``actionable knowledge units,'' foregrounding Actionability~(A) as a first-class concern complementary to FAIR.
+Building on YODA and this emphasis on actionability, the VAMP formulation\cite{hankeWhatDataLadWhat2023} (Versioned, Actionable, Modular, Portable) made Actionability~(A), Portability~(P), and Modularity~(M) explicit organizational requirements, and introduced Ephemerality~(E) as validation for Portability~(P)---directly prefiguring STAMPED.
+Notably, the WCI-FW framework\cite{wilkinsonApplyingFAIRPrinciples2025} extended FAIR to computational workflows but explicitly declined to define new principles, leaving the operational gap  that STAMPED fills (how a research object should be structured and managed).
 
 Independent of these normative efforts, a parallel ``Git for data'' convergence occurred in tooling.
-git-annex (2010), Git~LFS (2015), DVC (2017), Pachyderm (2014), and Icechunk\cite{abernathey_icechunk_2024} (2024) all independently arrived at content-addressed identification of large files, logical separation of metadata from bulk storage, and derivation records linking inputs to outputs.
+git-annex (2010), Git~LFS (2015), DVC (2017), Pachyderm (2014), and Icechunk\cite{abernatheyIcechunkOpenSourceTransactional2024} (2024) all independently arrived at content-addressed identification of large files, logical separation of metadata from bulk storage, and derivation records linking inputs to outputs.
 These systems vary widely in architecture, ranging from cloud-native to local-first and from centralized to distributed.
 Despite these differences, each converged on the same core insight, that version-control semantics proven for code could and should extend to data.
 This convergence is evidence not of influence but of shared need, and maps most directly onto Tracking~(T).
 
 A complementary convergence emerged in platforms and metadata standards.
-Though not an exhaustive list: Galaxy\cite{afgan_galaxy_2018} (first released 2005), Code~Ocean\cite{cheifet_promoting_2021} (2017), and brainlife.io\cite{hayashi_brainlifeio_2024} each provided turnkey reproducibility services, each implementing separation of code, data, and environment as a first-class abstraction---reflecting Self-containment~(S), Actionability~(A), and Portability~(P).
-On the standards side, the W3C~PROV data model (2013), Frictionless Data\cite{fowler_frictionless_2018} (2007), RO-Crate\cite{peroni_packaging_2022}, and BioComputeObject\cite{ferrer_biocompute_2017} (IEEE~2791-2020, \httpsurl{biocomputeobject.org}) each addressed interoperable packaging and provenance recording.
-The facts that FAIR required elaboration to accommodate software\cite{barker_introducing_2022} and workflows\cite{goble_fair_2020,wilkinson_applying_2025}, and that independent standards converged on provenance and packaging, confirms that these dimensions are recurrently demanded by research practice.
+Though not an exhaustive list: Galaxy\cite{afganGalaxyPlatformAccessible2018} (first released 2005), Code~Ocean\cite{cheifetPromotingReproducibilityCode2021} (2017), and brainlife.io\cite{hayashiBrainlifeioDecentralizedOpensource2024} each provided turnkey reproducibility services, each implementing separation of code, data, and environment as a first-class abstraction---reflecting Self-containment~(S), Actionability~(A), and Portability~(P).
+On the standards side, the W3C~PROV data model (2013), Frictionless Data\cite{fowlerFrictionlessDataMaking2018} (2007), RO-Crate\cite{soiland-reyesPackagingResearchArtefacts2022}, and BioComputeObject\cite{ferrerBioComputeProjectBioComputeObjects2017} (IEEE~2791-2020, \httpsurl{biocomputeobject.org}) each addressed interoperable packaging and provenance recording.
+The facts that FAIR required elaboration to accommodate software\cite{barkerIntroducingFAIRPrinciples2022} and workflows\cite{gobleFAIRComputationalWorkflows2020,wilkinsonApplyingFAIRPrinciples2025}, and that independent standards converged on provenance and packaging, confirms that these dimensions are recurrently demanded by research practice.
 
 Preregistration is the practice of committing to a study plan before outcomes are observed, which extends Tracking~(T) to the intent behind a study.
-It was established in clinical trials by the early 2000s and gradually expanded into behavioral, social, and computational research\cite{nosek_preregistration_2018}.
-The Open Science Framework\cite{foster_open_2017} (2013) combined that practice with a ``hub'' for collaboration and storage, producing read-only snapshots of a study's plan, data, code, and manuscripts under a single DOI, reflecting Self-containment~(S) and Distributability~(D).
+It was established in clinical trials by the early 2000s and gradually expanded into behavioral, social, and computational research\cite{nosekPreregistrationRevolution2018}.
+The Open Science Framework\cite{fosterOpenScienceFramework2017} (2013) combined that practice with a ``hub'' for collaboration and storage, producing read-only snapshots of a study's plan, data, code, and manuscripts under a single DOI, reflecting Self-containment~(S) and Distributability~(D).
 In some cases, pre-registration can also be considered a precursor to the Ephemerality~(E) of the actual scientific pipeline where work is concentrated on formulating hypothesis, planing and potentially simulations, thus making actual later implementation of it replaceable. 
 
 Framework tooling and domain standards reveal the same pattern at the project-layout level.
-Cookiecutter Data Science (2016), BIDS\cite{gorgolewski_brain_2016} (2016), Kedro (2019), nipoppy\cite{wang_open_2026} (2023), and others, all imposed opinionated directory structures and modular separation (independently motivated by the costs of ad-hoc layouts)---reflecting Modularity~(M) and Self-containment~(S).
+Cookiecutter Data Science (2016), BIDS\cite{gorgolewskiBrainImagingData2016a} (2016), Kedro (2019), nipoppy\cite{wangOpenNeuroinformaticsInfrastructure2026} (2023), and others, all imposed opinionated directory structures and modular separation (independently motivated by the costs of ad-hoc layouts)---reflecting Modularity~(M) and Self-containment~(S).
 Each framework constrains where code and documentation reside, how raw data inputs and derived outputs are handled, which makes such projects navigable by \emph{convention}.
 
 Viewed together, these independent lines of development map onto every STAMPED principle.
@@ -566,22 +566,22 @@ The remainder of the section then addresses the more specific and fast-moving ch
 
 Ephemerality~(E), as formulated here, treats the compute environment as disposable while the code and data it runs on remain durable.
 A complementary view is emerging in which workflow implementations themselves become regenerable from a durable specification.
-Declarative workflow languages such as CWL\cite{crusoe_methods_2022}, Snakemake\cite{molder_sustainable_2021}, and Nextflow\cite{di_tommaso_nextflow_2017}, together with fully-declarative environment managers such as Nix\cite{kowalewski_sustainable_2022} and Guix\cite{courtes_reproducible_2015}, already operate this way.
+Declarative workflow languages such as CWL\cite{crusoeMethodsIncludedStandardizing2022}, Snakemake\cite{molderSustainableDataAnalysis2021}, and Nextflow\cite{ditommasoNextflowEnablesReproducible2017}, together with fully-declarative environment managers such as Nix\cite{kowalewskiSustainablePackagingQuantum2022} and Guix\cite{courtesReproducibleUserControlledSoftware2015}, already operate this way.
 The specification accumulates the domain knowledge, including inputs, constraints, expected outputs, and validation criteria, while any given implementation can be rebuilt or replaced without loss.
 Under this view, STAMPED principles apply to the specification first and the generated implementation second.
 The specification is what must be Self-contained~(S), Tracked~(T), Actionable~(A), and Distributable~(D), while the running code is Ephemeral~(E) in the same sense as a container.
-The connection to pre-registration is direct and generalizes Ephemerality~(E) even further\cite{nosek_preregistration_2018}.
+The connection to pre-registration is direct and generalizes Ephemerality~(E) even further\cite{nosekPreregistrationRevolution2018}.
 A well-formulated study specification is a commitment that survives any particular implementation, and what is Ephemeral~(E) expands from the compute environment to the full ``scientific middleware'' (data acquisition,
 harmonization, preprocessing, analytics), with each stage reduced to a specification from which implementations can be derived.
-OSF Registrations\cite{foster_open_2017} already operate this way for preregistered plans, fixing a study's specification under a DOI before any implementation begins.
+OSF Registrations\cite{fosterOpenScienceFramework2017} already operate this way for preregistered plans, fixing a study's specification under a DOI before any implementation begins.
 That is where concentration on formalization and standardization of overall study specifications becomes the target to apply STAMPED principles, so that the middleware steps could also be automatically carried out in an Ephemeral~(E) fashion and potentially while exploring various possible implementations.
-The cost of under-specified middleware is already visible in practice; the NARPS study showed that 70 independent teams analyzing the same fMRI dataset with nominally similar hypotheses produced substantially divergent results\cite{botvinik-nezer_variability_2020}, precisely because the study specification left most of the middleware up to each team.
+The cost of under-specified middleware is already visible in practice; the NARPS study showed that 70 independent teams analyzing the same fMRI dataset with nominally similar hypotheses produced substantially divergent results\cite{botvinik-nezerVariabilityAnalysisSingle2020}, precisely because the study specification left most of the middleware up to each team.
 
 \anchoredsubsubsection{provenance-standards}{Provenance standards convergence}
 
 As FAIR leaves specific protocols and standards open, STAMPED likewise does not prescribe a serialization for provenance records, and in practice researchers rely on whatever their tooling emits.
 Convergence among existing approaches would let STAMPED research objects carry Portable~(P) provenance across toolchains without lock-in.
-Relevant efforts include cross-domain standards such as W3C PROV\cite{w3c_provenance_working_group_prov-overview_2013} and RO-Crate\cite{peroni_packaging_2022}, tool-level records such as DataLad's\cite{halchenko_datalad_2021} \texttt{datalad run} provenance, and domain-specific specifications such as BIDS-Prov (BEP028)\cite{bids_community_bep028_2025}.
+Relevant efforts include cross-domain standards such as W3C PROV\cite{w3cprovenanceworkinggroupPROVOverviewOverviewPROV2013} and RO-Crate\cite{soiland-reyesPackagingResearchArtefacts2022}, tool-level records such as DataLad's\cite{halchenkoDataLadDistributedSystem2021} \texttt{datalad run} provenance, and domain-specific specifications such as BIDS-Prov (BEP028)\cite{bidscommunityBEP028BIDSExtension2025}.
 This is less a change to STAMPED itself than a call on these communities: Tracking (T) becomes substantially more useful when provenance records follow shared standards and can be exported, compared, and re-interpreted by tools other than the one that generated them.
 
 
@@ -589,8 +589,8 @@ This is less a change to STAMPED itself than a call on these communities: Tracki
 
 STAMPED compliance today is self-assessed against the checklist fulfilling a simple LinkML model\cite{stamped-checklist-schema:v0.1.0} presented in this paper, and exposed to users in a convenient Web UI at the \httpsurl{checklist.stamped-principles.org} webpage.
 That Web UI provides Self-contained~(S) stateful permalinks to render any particular state of the filled out checklist, so they could be shared easily.
-Broader adoption will depend on promotion and external incentives, including funder mandates (e.g.,\ NIH Data Management and Sharing policies), journal reproducibility badges\cite{center_for_open_science_open_2023}, and venue-level review checklists that converge toward automated scoring. 
-Such a trajectory would parallel that of FAIR, which has moved from principles to machine-assessable indicators with tools such as F-UJI\cite{devaraju_automated_2021}.
+Broader adoption will depend on promotion and external incentives, including funder mandates (e.g.,\ NIH Data Management and Sharing policies), journal reproducibility badges\cite{centerforopenscienceOpenScienceBadges2023}, and venue-level review checklists that converge toward automated scoring. 
+Such a trajectory would parallel that of FAIR, which has moved from principles to machine-assessable indicators with tools such as F-UJI\cite{devarajuAutomatedSolutionMeasuring2021}.
 No automated tool yet available as of now certifies STAMPED compliance.
 A community-maintained benchmark suite, seeded by the satellite examples project associated with this paper (\httpsurl{examples.stamped-principles.org}), is a natural precursor.
 
@@ -600,16 +600,16 @@ A community-maintained benchmark suite, seeded by the satellite examples project
 Uptake through formal training is slow but compounding.
 As the ``train the trainer'' model used by the ReproNim program has demonstrated, students and researchers who encounter these practices early in their career become some of the most effective propagators of open science, even if that propagation takes years to surface.
 Existing resources already teach most of what STAMPED asks for, without using the term.
-These include EduWrench\cite{casanova_eduwrench_2023}, the Reproducible Research MOOC which teaches \texttt{git-annex} and related tools\cite{legrand_reproducible_2022}, and RDMkit data analysis best practices\cite{elixir_rdmkit_community_data_2024}.
+These include EduWrench\cite{casanovaEduWrenchPedagogicModules2023}, the Reproducible Research MOOC which teaches \texttt{git-annex} and related tools\cite{legrandReproducibleResearchII2022}, and RDMkit data analysis best practices\cite{elixirrdmkitcommunityDataAnalysisBest2024}.
 Curricular integration with open-science and neuroimaging training programs such as Brainhack would close the gap between practitioners who apply these practices by habit and those who can name what they are doing and evaluate it against a shared checklist.
 YODA principles have already entered the curricula of several such programs, and we expect their references to migrate toward the more formally articulated STAMPED vocabulary.
-Continued community outreach, including a recent introduction to STAMPED\cite{baker_guidelines_2026} delivered to the BRAIN BBQS program, supports that transition.
+Continued community outreach, including a recent introduction to STAMPED\cite{bakerGuidelinesReproducibleResearch2026} delivered to the BRAIN BBQS program, supports that transition.
 
 
 \anchoredsubsubsection{ai-era}{Research in an AI Era}
 
-AI agents are now generating analysis code, selecting methods, and in some systems running entire research cycles end-to-end\cite{boiko_autonomous_2023, lu_ai_2024, mitchener_kosmos_2025}.
-Without explicit structure, this automation can produce results whose provenance and reasoning are irrecoverable\cite{messeri_artificial_2024}.
+AI agents are now generating analysis code, selecting methods, and in some systems running entire research cycles end-to-end\cite{boikoAutonomousChemicalResearch2023, luAIScientistFully2024, mitchenerKosmosAIScientist2025}.
+Without explicit structure, this automation can produce results whose provenance and reasoning are irrecoverable\cite{messeriArtificialIntelligenceIllusions2024}.
 The STAMPED principles already carry most of what is needed.
 Self-contained~(S) workspaces alone give agents a well-defined boundary; Tracked~(T) histories make agent contributions auditable and contribute to their ``memory''; Actionable~(A) documentation serves humans and machines alike.
 As with any new methodology or instrumentation entering science, several of these principles need AI-era extensions.
@@ -622,13 +622,13 @@ Even where models are nominally versioned, the degree of control varies widely, 
 Self-containment~(S) extends naturally to this case: models are Tracked~(T) components of the research object, just as data and code are today.
 Practical mechanisms exist for open models, such as pinned revisions on Hugging Face or, for durable Self-containment~(S), archival copies managed via \texttt{git-annex}.
 Tracking what training data and procedures produced a given model remains an open problem that intersects copyright, benchmarking, and provenance, and is mostly beyond what STAMPED can prescribe.
-Community artifacts such as Model Cards\cite{mitchell_model_2019} and Datasheets for Datasets\cite{gebru_datasheets_2021} nonetheless point toward the shape of an answer.
+Community artifacts such as Model Cards\cite{mitchellModelCardsModel2019} and Datasheets for Datasets\cite{gebruDatasheetsDatasets2021} nonetheless point toward the shape of an answer.
 
 \paragraph{Provenance for AI-driven changes.}
 When an AI agent modifies code, generates analysis scripts, or makes architectural decisions, those actions become part of the research record.
 Tracking (T) naturally extends to cover agent actions by wrapping an agent invocation in a provenance-capturing command such as \texttt{datalad run} to record the model, prompt, and resulting changes alongside the output.
 Some of this provenance is already captured organically through git commits authored by agents, session transcripts, and co-authorship metadata.
-Emerging tools such as Entire CLI\cite{entire_entire_2026} go further, automating capture of the entire AI session alongside the commit.
+Emerging tools such as Entire CLI\cite{entireEntireCLIGit2026} go further, automating capture of the entire AI session alongside the commit.
 A practical tension follows wherein agent sessions can produce enormous transcripts, and including them wholesale may dilute the value of more targeted provenance records, so what to capture and at what granularity remain open questions.
 Bitwise reproducibility is not the target and rarely is the goal even for human-driven steps.
 Instead, what the record must preserve is the hypothesis, the method specification, and enough of the decision trail to support introspection.
@@ -636,14 +636,14 @@ Self-contained~(S) models (above) strengthen this chain---when the model itself 
 
 \paragraph{Machine-actionable instructions.}
 Actionability~(A) was defined with human operators in mind, including entry-point commands documented in READMEs, frequently incomplete or out of sync with the underlying workflow.
-AI agents are a second consumer of the same prose, one that can parse, follow, and correct instructions on the fly, and plain Markdown has effectively become the interface language: \texttt{AGENTS.md} files, README-driven agent workflows, and spec-kit\cite{github_spec_2025} collections now function as machine-actionable interfaces, making Self-contained~(S) and Tracked~(T) research objects more Actionable~(A).
+AI agents are a second consumer of the same prose, one that can parse, follow, and correct instructions on the fly, and plain Markdown has effectively become the interface language: \texttt{AGENTS.md} files, README-driven agent workflows, and spec-kit\cite{githubSpecKitToolkit2025} collections now function as machine-actionable interfaces, making Self-contained~(S) and Tracked~(T) research objects more Actionable~(A).
 Where prose instructions fail, the failure is legible (an audit mechanism that did not exist before) even if agent-driven execution remains less reliable than deterministic tooling.
 
 \paragraph{AI-accelerated specification-to-implementation.}
 Specification-centric research objects (above) depend on the cost of regenerating an implementation from a specification being low enough to be routine.
 AI coding assistants and specification-driven toolkits such as spec-kit move this cost toward zero, making the spec-centric view practical rather than aspirational.
 This holds provided the preceding extensions for models, provenance, and machine-actionable instructions are in place.
-This closes a loop with the end-to-end ``AI scientist'' systems that opened this section\cite{boiko_autonomous_2023, lu_ai_2024, mitchener_kosmos_2025}.
+This closes a loop with the end-to-end ``AI scientist'' systems that opened this section\cite{boikoAutonomousChemicalResearch2023, luAIScientistFully2024, mitchenerKosmosAIScientist2025}.
 As soon as an agentic pipeline takes a study specification and returns data, code, figures, and a draft manuscript, the specification and every downstream artifact must together satisfy STAMPED, not only to keep such pipelines efficient to re-run at lower cost but to make their outputs introspectable.
 Tracked~(T) and Self-contained~(S) research objects let a researcher inspect which model, prompt, and decision led to a particular result, implement ``hand over'' between humans and agents alike and let subsequent actor re-enter any prior state and continue from it without rediscovering context.
 At the end, human scientists authoring and iterating over the specification of a STAMPED research object would see how their edits propagate through the generated implementation.
@@ -685,7 +685,7 @@ The authors declare no competing interests.
 \anchoredsection{acknowledgments}{Acknowledgments}
 
 STAMPED builds directly on prior community efforts to articulate principles for reproducible research data management.
-We are grateful to Michael Hanke and Adina S.\ Wagner for the conceptual development of VAMP\cite{hanke_what_2023}, and to the authors of the original YODA poster\cite{hanke_yoda_2018}---Michael Hanke, Matteo Visconti di Oleggio Castello, Kyle Meyer, and Benjamin Poldrack---whose work laid the foundations on which this formalization rests.
+We are grateful to Michael Hanke and Adina S.\ Wagner for the conceptual development of VAMP\cite{hankeWhatDataLadWhat2023}, and to the authors of the original YODA poster\cite{hankeYODAYODAsOrganigram2018}---Michael Hanke, Matteo Visconti di Oleggio Castello, Kyle Meyer, and Benjamin Poldrack---whose work laid the foundations on which this formalization rests.
 We thank Jiameng Wu for filing issues and contributing editorial improvements to the manuscript.
 
 This manuscript and companion materials in the \ghurl{stamped-principles} organization were prepared with the assistance of agentic AI coding tools and large language models (primarily Claude Opus).

--- a/references.bib
+++ b/references.bib
@@ -2513,3 +2513,37 @@ First alpha release of the STAMPED principles schema.},
 	year = {2018},
 	note = {Published: Poster presented at the annual meeting of the Organization for Human Brain Mapping, Singapore},
 }
+
+% ---------------------------------------------------------------------------
+% Hand-maintained entries -- NOT in the Zotero group library.
+%
+% code/fetch-zotero-bib.sh regenerates this file from the library, so it cannot
+% produce these two and any regeneration drops them silently. They are re-added
+% here so the manuscript keeps building.
+%
+% Tracked in issue #197: once both works are in the library, delete this block
+% and let the fetch script emit them like every other entry. The SPDX entry
+% below is reproduced verbatim and has two known defects corrected there -- the
+% field name is "do" rather than "doi", and the value is unregistered (the
+% working DOI is 10.5033/ifosslr.v4i1.45).
+% ---------------------------------------------------------------------------
+
+@article{stewart_software_2010,
+  author = {Stewart, Kate and Odence, Phil and Rockett, Esteban},
+  title = {Software Package Data Exchange ({SPDX}) Specification},
+  journal = {International Free and Open Source Software Law Review},
+  volume = {2},
+  number = {2},
+  pages = {191--196},
+  year = {2010},
+  do = {10.5033/ifosslr.v2i2.45},
+  url = {https://www.ifosslr.org/ifosslr/article/view/45}
+}
+
+@misc{fsfe_reuse_2024,
+  author = {{Free Software Foundation Europe}},
+  title = {{REUSE} Specification, Version 3.3},
+  year = {2024},
+  url = {https://reuse.software/spec-3.3/}
+}
+

--- a/references.bib
+++ b/references.bib
@@ -1,5 +1,5 @@
 
-@article{haxby_common_2011,
+@article{haxbyCommonHighDimensionalModel2011,
 	title = {A {Common}, {High}-{Dimensional} {Model} of the {Representational} {Space} in {Human} {Ventral} {Temporal} {Cortex}},
 	volume = {72},
 	issn = {0896-6273},
@@ -12,7 +12,7 @@
 	pages = {404--416},
 }
 
-@article{hanke_communication_2015,
+@article{hankeCommunicationHubDecentralized2015,
 	title = {A communication hub for a decentralized collaboration on studying real-life cognition},
 	volume = {4},
 	doi = {10.12688/f1000research.6229.1},
@@ -22,7 +22,7 @@
 	year = {2015},
 }
 
-@article{subash_comparison_2023,
+@article{subashComparisonNeuroelectrophysiologyDatabases2023,
 	title = {A comparison of neuroelectrophysiology databases},
 	volume = {10},
 	issn = {2052-4463},
@@ -41,7 +41,7 @@
 	pages = {719},
 }
 
-@article{hawrylycz_guide_2023,
+@article{hawrylyczGuideBRAINInitiative2023,
 	title = {A guide to the {BRAIN} {Initiative} {Cell} {Census} {Network} data ecosystem},
 	volume = {21},
 	url = {https://doi.org/10.1371/journal.pbio.3002133},
@@ -55,7 +55,7 @@
 	pages = {1--30},
 }
 
-@article{guntupalli_model_2016,
+@article{guntupalliModelRepresentationalSpaces2016,
 	title = {A {Model} of {Representational} {Spaces} in {Human} {Cortex}},
 	issn = {1047-3211, 1460-2199},
 	doi = {10.1093/cercor/bhw068},
@@ -64,11 +64,10 @@
 	author = {Guntupalli, J. Swaroop and Hanke, Michael and Halchenko, Yaroslav O. and Connolly, Andrew C. and Ramadge, Peter J. and Haxby, James V.},
 	month = jun,
 	year = {2016},
-	pmid = {26980615},
 	pages = {2919--2934},
 }
 
-@article{brain_initiative_cell_census_network_biccn_multimodal_2020,
+@article{braininitiativecellcensusnetworkbiccnMultimodalCellCensus2020,
 	title = {A multimodal cell census and atlas of the mammalian primary motor cortex},
 	url = {https://www.biorxiv.org/content/early/2020/10/21/2020.10.19.343129},
 	doi = {10.1101/2020.10.19.343129},
@@ -78,7 +77,16 @@
 	year = {2020},
 }
 
-@misc{heejung_jung_multimodal_2025,
+@article{jungMultimodalFMRIDataset2024,
+	title = {A multimodal {fMRI} dataset unifying naturalistic processes with a rich array of experimental tasks},
+	url = {http://dx.doi.org/10.1101/2024.06.21.599974},
+	doi = {10.1101/2024.06.21.599974},
+	author = {Jung, Heejung and Amini, Maryam and Hunt, Bethany J and Murphy, Eilis I and Sadil, Patrick and Halchenko, Yaroslav O and Petre, Bogdan and Miao, Zizhuang and Kragel, Philip A and Han, Xiaochun and Heilicher, Mickela O and Sun, Michael and Collins, Owen G and Lindquist, Martin A and Wager, Tor D},
+	month = jun,
+	year = {2024},
+}
+
+@misc{heejungjungMultimodalFMRIDataset2025,
 	title = {A multimodal {fMRI} dataset unifying naturalistic processes with a rich array of experimental tasks},
 	url = {https://openneuro.org/datasets/ds005256/versions/1.1.0},
 	doi = {10.18112/OPENNEURO.DS005256.V1.1.0},
@@ -88,16 +96,7 @@
 	year = {2025},
 }
 
-@article{jung_multimodal_2024,
-	title = {A multimodal {fMRI} dataset unifying naturalistic processes with a rich array of experimental tasks},
-	url = {http://dx.doi.org/10.1101/2024.06.21.599974},
-	doi = {10.1101/2024.06.21.599974},
-	author = {Jung, Heejung and Amini, Maryam and Hunt, Bethany J and Murphy, Eilis I and Sadil, Patrick and Halchenko, Yaroslav O and Petre, Bogdan and Miao, Zizhuang and Kragel, Philip A and Han, Xiaochun and Heilicher, Mickela O and Sun, Michael and Collins, Owen G and Lindquist, Martin A and Wager, Tor D},
-	month = jun,
-	year = {2024},
-}
-
-@article{noble_quick_2009,
+@article{nobleQuickGuideOrganizing2009,
 	title = {A {Quick} {Guide} to {Organizing} {Computational} {Biology} {Projects}},
 	volume = {5},
 	issn = {1553-7358},
@@ -114,7 +113,7 @@
 	pages = {e1000424},
 }
 
-@article{zhao_reproducible_2024,
+@article{zhaoReproducibleGeneralizableSoftware2024,
 	title = {A reproducible and generalizable software workflow for analysis of large-scale neuroimaging data collections using {BIDS} {Apps}},
 	volume = {2},
 	issn = {2837-6056},
@@ -131,7 +130,7 @@
 	pages = {imag--2--00074},
 }
 
-@article{ghosh_very_2017,
+@article{ghoshVerySimpleReexecutable2017,
 	title = {A very simple, re-executable neuroimaging publication},
 	volume = {6},
 	issn = {2046-1402},
@@ -148,7 +147,16 @@
 	pages = {124},
 }
 
-@article{baranger_aberrant_2021,
+@article{barangerAberrantLevelsCortical2021,
+	title = {Aberrant levels of cortical myelin distinguish individuals with unipolar depression from healthy controls},
+	url = {https://doi.org/10.1101/2021.02.25.21252472},
+	doi = {10.1101/2021.02.25.21252472},
+	author = {Baranger, David A. A. and Halchenko, Yaroslav O. and Satz, Skye and Ragozzino, Rachel and Iyengar, Satish and Swartz, Holly A. and Manelis, Anna},
+	month = mar,
+	year = {2021},
+}
+
+@article{barangerAberrantLevelsCortical2021a,
 	title = {Aberrant levels of cortical myelin distinguish individuals with unipolar depression from healthy controls},
 	url = {https://www.medrxiv.org/content/early/2021/03/01/2021.02.25.21252472},
 	doi = {10.1101/2021.02.25.21252472},
@@ -158,16 +166,7 @@
 	year = {2021},
 }
 
-@article{baranger_aberrant_2021-1,
-	title = {Aberrant levels of cortical myelin distinguish individuals with unipolar depression from healthy controls},
-	url = {https://doi.org/10.1101/2021.02.25.21252472},
-	doi = {10.1101/2021.02.25.21252472},
-	author = {Baranger, David A. A. and Halchenko, Yaroslav O. and Satz, Skye and Ragozzino, Rachel and Iyengar, Satish and Swartz, Holly A. and Manelis, Anna},
-	month = mar,
-	year = {2021},
-}
-
-@incollection{landini_advanced_2005,
+@incollection{halchenkoAdvancedImageProcessing2005,
 	address = {Boca Raton},
 	title = {Advanced {Image} {Processing} in {Magnetic} {Resonance} {Imaging}: {fMRI}, {MRI}, {EEG}, {MEG}},
 	url = {http://www.onerussian.com/Sci/fusion},
@@ -180,7 +179,7 @@
 	pages = {223--65},
 }
 
-@article{halchenko_advancing_2010,
+@article{halchenkoAdvancingNeuroimagingResearch2010,
 	title = {Advancing {Neuroimaging} {Research} with {Predictive} {Multivariate} {Pattern} {Analysis}},
 	doi = {10.2417/1200909.1683},
 	journal = {The Neuromorphic Engineer},
@@ -189,7 +188,7 @@
 	year = {2010},
 }
 
-@article{kiar_align_2023,
+@article{kiarAlignNMINDConsortium2023,
 	title = {Align with the {NMIND} consortium for better neuroimaging},
 	url = {https://doi.org/10.1038/s41562-023-01647-0},
 	doi = {10.1038/s41562-023-01647-0},
@@ -199,7 +198,7 @@
 	year = {2023},
 }
 
-@article{devaraju_automated_2021,
+@article{devarajuAutomatedSolutionMeasuring2021,
 	title = {An automated solution for measuring the progress toward {FAIR} research data},
 	volume = {2},
 	issn = {2666-3899},
@@ -214,7 +213,7 @@
 	pages = {100370},
 }
 
-@article{esteban_analysis_2020,
+@article{estebanAnalysisTaskbasedFunctional2020,
 	title = {Analysis of task-based functional {MRI} data preprocessed with {fMRIPrep}},
 	url = {https://www.biorxiv.org/content/early/2020/01/03/694364},
 	doi = {10.1101/694364},
@@ -224,14 +223,14 @@
 	year = {2020},
 }
 
-@misc{nichols_application_2015,
+@misc{nicholsApplicationNeuroimagingData2015,
 	title = {Application of the {Neuroimaging} {Data} {Model} to {Represent} and {Exchange} {Primary} and {Derived} {Data}},
 	author = {Nichols, Nolan and Keator, David and Maumet, Camille and Flandin, Guillaume and Nichols, Thomas and Gorgolewski, Krzysztof and Halchenko, Yaroslav and Hanke, Michael and Haselgrove, Christian and Helmer, Karl and Marcus, Daniel and Poldrack, Russell and Turner, Jessica and Kennedy, David and Poline, Jean Baptiste and Pohl, Kilian},
 	year = {2015},
 	note = {Published: Organization of Human Brain Mapping Annual Meeting, Honolulu HI, USA. Poster},
 }
 
-@article{wilkinson_applying_2025,
+@article{wilkinsonApplyingFAIRPrinciples2025,
 	title = {Applying the {FAIR} {Principles} to computational workflows},
 	volume = {12},
 	issn = {2052-4463},
@@ -247,7 +246,7 @@
 	pages = {328},
 }
 
-@inproceedings{timchenko_approach_1999,
+@inproceedings{timchenkoApproachParallelhierarchicalNetwork1999,
 	title = {Approach to parallel-hierarchical network learning for real-time image sequence recognition},
 	volume = {3836:1},
 	doi = {10.1117/12.360283},
@@ -256,11 +255,10 @@
 	author = {Timchenko, L. I. and Kutaev, Y. F. and Gertsiy, A. A. and Zahoruiko, L. V. and Halchenko, Y. O. and Mansur, T.},
 	editor = {Miller, J. W. V. and Solomon, S. S. and Batchelor, B. G.},
 	year = {1999},
-	note = {event-place: Boston, MA, USA},
 	pages = {71--81},
 }
 
-@article{messeri_artificial_2024,
+@article{messeriArtificialIntelligenceIllusions2024,
 	title = {Artificial intelligence and illusions of understanding in scientific research},
 	volume = {627},
 	issn = {0028-0836, 1476-4687},
@@ -276,30 +274,21 @@
 	pages = {49--58},
 }
 
-@misc{nastase_attention_2015,
+@misc{nastaseAttentionAltersAnimal2015,
 	title = {Attention alters animal and action representation in highly-distributed functionally-defined cortical parcels},
 	author = {Nastase, Samuel A. and Visconti di Oleggio Castello, Matteo and Halchenko, Yaroslav O. and Connolly, Andrew C. and Oosterhof, Nikolaas N. and and Gobbini, M. Ida and Haxby, James V.},
 	year = {2015},
 	note = {Published: Poster presented at the annual meeting of the Society for Neuroscience, Chicago, IL},
 }
 
-@misc{nastase_attention_2014,
+@misc{nastaseAttentionLocallyModulates2014,
 	title = {Attention locally modulates the discriminability of high-level, task-relevant representations},
 	author = {Nastase, Samuel A. and Connolly, Andrew C. and Oosterhof, Nikolaas N. and Halchenko, Yaroslav O. and Gors, Jason and Gobbini, M. Ida and Haxby, James V.},
 	year = {2014},
 	note = {Published: Poster presented at the annual meeting of the Organization for Human Brain Mapping, Hamburg, Germany},
 }
 
-@article{nastase_attention_2016,
-	title = {Attention selectively reshapes the geometry of distributed semantic representation},
-	url = {http://biorxiv.org/content/early/2016/03/23/045252},
-	doi = {10.1101/045252},
-	journal = {bioRxiv},
-	author = {Nastase, Samuel A. and Connolly, Andrew C. and Oosterhof, Nikolaas N. and Halchenko, Yaroslav O. and Guntupalli, J. Swaroop and Visconti di Oleggio Castello, Matteo and Gors, Jason and Gobbini, M. Ida and Haxby, James V.},
-	year = {2016},
-}
-
-@article{nastase_attention_2017,
+@article{nastaseAttentionSelectivelyReshapes2017,
 	title = {Attention selectively reshapes the geometry of distributed semantic representation},
 	volume = {27},
 	url = {https://doi.org/10.1093/cercor/bhx138},
@@ -310,14 +299,23 @@
 	pages = {4277--4291},
 }
 
-@misc{nastase_attentional_2014,
+@article{nastaseAttentionSelectivelyReshapes2016,
+	title = {Attention selectively reshapes the geometry of distributed semantic representation},
+	url = {http://biorxiv.org/content/early/2016/03/23/045252},
+	doi = {10.1101/045252},
+	journal = {bioRxiv},
+	author = {Nastase, Samuel A. and Connolly, Andrew C. and Oosterhof, Nikolaas N. and Halchenko, Yaroslav O. and Guntupalli, J. Swaroop and Visconti di Oleggio Castello, Matteo and Gors, Jason and Gobbini, M. Ida and Haxby, James V.},
+	year = {2016},
+}
+
+@misc{nastaseAttentionalAllocationLocally2014,
 	title = {Attentional allocation locally warps representational space},
 	author = {Nastase, Samuel A. and Connolly, Andrew C. and Oosterhof, Nikolaas N. and Halchenko, Yaroslav O. and Gors, Jason and Gobbini, M. Ida and Haxby, James V.},
 	year = {2014},
 	note = {Published: Poster presented at the annual meeting of the Vision Sciences Society, St. Pete Beach, FL},
 }
 
-@article{boiko_autonomous_2023,
+@article{boikoAutonomousChemicalResearch2023,
 	title = {Autonomous chemical research with large language models},
 	volume = {624},
 	issn = {0028-0836, 1476-4687},
@@ -344,7 +342,7 @@
 	pages = {570--578},
 }
 
-@article{han_behaviorally-relevant_2024,
+@article{hanBehaviorallyrelevantFeaturesObserved2024,
 	title = {Behaviorally-relevant features of observed actions dominate cortical representational geometry in natural vision},
 	url = {http://dx.doi.org/10.1101/2024.11.26.624178},
 	doi = {10.1101/2024.11.26.624178},
@@ -353,7 +351,7 @@
 	year = {2024},
 }
 
-@misc{bids_community_bep028_2025,
+@misc{bidscommunityBEP028BIDSExtension2025,
 	title = {{BEP028}: {BIDS} {Extension} {Proposal} for {BIDS} {Provenance}},
 	url = {https://github.com/bids-standard/BEP028_BIDSprov},
 	urldate = {2026-04-19},
@@ -362,7 +360,7 @@
 	note = {Published: BIDS Extension Proposal},
 }
 
-@article{ferrer_biocompute_2017,
+@article{ferrerBioComputeProjectBioComputeObjects2017,
 	title = {{BioCompute} {Project} (\#{BioComputeObjects})},
 	copyright = {Creative Commons Attribution 4.0 International},
 	url = {https://osf.io/h59uh/},
@@ -405,7 +403,7 @@ Tweet \#BioCompute @BioComputeObj},
 	keywords = {High-throughput Sequencing, Next-Gen Sequencing, biocomputing, bioinformatics, interoprability, standards},
 }
 
-@article{hanson_bottom-up_2007,
+@article{hansonBottomupTopdownBrain2007,
 	title = {Bottom-up and top-down brain functional connectivity underlying comprehension of everyday visual action},
 	volume = {212},
 	issn = {1863-2653},
@@ -419,7 +417,7 @@ Tweet \#BioCompute @BioComputeObj},
 	pages = {231--44},
 }
 
-@article{hanson_brain_2008,
+@article{hansonBrainReadingUsing2008,
 	title = {Brain reading using full brain support vector machines for object recognition: there is no “face” identification area},
 	volume = {20},
 	issn = {0899-7667},
@@ -430,7 +428,7 @@ Tweet \#BioCompute @BioComputeObj},
 	pages = {486--503},
 }
 
-@article{gau_brainhack_2021,
+@article{gauBrainhackDevelopingCulture2021,
 	title = {Brainhack: {Developing} a culture of open, inclusive, community-driven neuroscience},
 	url = {https://doi.org/10.1016/j.neuron.2021.04.001},
 	doi = {10.1016/j.neuron.2021.04.001},
@@ -440,7 +438,7 @@ Tweet \#BioCompute @BioComputeObj},
 	year = {2021},
 }
 
-@article{hayashi_brainlifeio_2024,
+@article{hayashiBrainlifeioDecentralizedOpensource2024,
 	title = {brainlife.io: a decentralized and open-source cloud platform to support neuroscience research},
 	volume = {21},
 	issn = {1548-7091, 1548-7105},
@@ -459,68 +457,68 @@ Tweet \#BioCompute @BioComputeObj},
 	pages = {809--813},
 }
 
-@inproceedings{chhetri_bridging_2025,
+@inproceedings{chhetriBridgingScientificKnowledge2025,
+	address = {Sydney NSW Australia},
+	title = {Bridging the {Scientific} {Knowledge} {Gap} and {Reproducibility}: {A} {Survey} of {Provenance}, {Assertion} and {Evidence} {Ontologies}},
+	isbn = {979-8-4007-1331-6},
+	shorttitle = {Bridging the {Scientific} {Knowledge} {Gap} and {Reproducibility}},
+	url = {https://dl.acm.org/doi/10.1145/3701716.3715483},
+	doi = {10.1145/3701716.3715483},
+	language = {en},
+	urldate = {2026-05-19},
+	booktitle = {Companion {Proceedings} of the {ACM} on {Web} {Conference} 2025},
+	publisher = {ACM},
+	author = {Chhetri, Tek Raj and Halchenko, Yaroslav O. and Jarecka, Dorota and Trivedi, Puja and Ghosh, Satrajit S. and Ray, Patrick and Ng, Lydia},
+	month = may,
+	year = {2025},
+	pages = {924--928},
+}
+
+@inproceedings{chhetriBridgingScientificKnowledge2025a,
+	address = {Sydney NSW Australia},
+	title = {Bridging the {Scientific} {Knowledge} {Gap} and {Reproducibility}: {A} {Survey} of {Provenance}, {Assertion} and {Evidence} {Ontologies}},
+	isbn = {979-8-4007-1331-6},
+	shorttitle = {Bridging the {Scientific} {Knowledge} {Gap} and {Reproducibility}},
+	url = {https://dl.acm.org/doi/10.1145/3701716.3715483},
+	doi = {10.1145/3701716.3715483},
+	language = {en},
+	urldate = {2026-05-19},
+	booktitle = {Companion {Proceedings} of the {ACM} on {Web} {Conference} 2025},
+	publisher = {ACM},
+	author = {Chhetri, Tek Raj and Halchenko, Yaroslav O. and Jarecka, Dorota and Trivedi, Puja and Ghosh, Satrajit S. and Ray, Patrick and Ng, Lydia},
+	month = may,
+	year = {2025},
+	pages = {924--928},
+}
+
+@inproceedings{chhetriBridgingScientificKnowledge2025b,
 	address = {Sydney, NSW, Australia},
 	title = {Bridging the {Scientific} {Knowledge} {Gap} and {Reproducibility}: {A} {Survey} of {Provenance}, {Assertion} and {Evidence} {Ontologies}},
-	isbn = {979-8-4007-1331-6/25/04},
+	isbn = {979-8-4007-1331-6},
+	url = {https://doi.org/10.1145/3701716.3715483},
 	doi = {10.1145/3701716.3715483},
 	booktitle = {Companion {Proceedings} of the {ACM} {Web} {Conference} 2025 (to appear)},
 	publisher = {ACM},
 	author = {Chhetri, Tek Raj and Halchenko, Yaroslav O. and Jarecka, Dorota and Trivedi, Puja and Ghosh, Satrajit and Ray, Patrick and Ng, Lydia},
 	month = may,
 	year = {2025},
-	note = {event-place: Sydney, NSW, Australia},
 }
 
-@inproceedings{chhetri_bridging_2025-1,
-	address = {Sydney NSW Australia},
-	title = {Bridging the {Scientific} {Knowledge} {Gap} and {Reproducibility}: {A} {Survey} of {Provenance}, {Assertion} and {Evidence} {Ontologies}},
-	isbn = {979-8-4007-1331-6},
-	shorttitle = {Bridging the {Scientific} {Knowledge} {Gap} and {Reproducibility}},
-	url = {https://dl.acm.org/doi/10.1145/3701716.3715483},
-	doi = {10.1145/3701716.3715483},
-	language = {en},
-	urldate = {2026-05-19},
-	booktitle = {Companion {Proceedings} of the {ACM} on {Web} {Conference} 2025},
-	publisher = {ACM},
-	author = {Chhetri, Tek Raj and Halchenko, Yaroslav O. and Jarecka, Dorota and Trivedi, Puja and Ghosh, Satrajit S. and Ray, Patrick and Ng, Lydia},
-	month = may,
-	year = {2025},
-	pages = {924--928},
-}
-
-@inproceedings{chhetri_bridging_2025-2,
-	address = {Sydney NSW Australia},
-	title = {Bridging the {Scientific} {Knowledge} {Gap} and {Reproducibility}: {A} {Survey} of {Provenance}, {Assertion} and {Evidence} {Ontologies}},
-	isbn = {979-8-4007-1331-6},
-	shorttitle = {Bridging the {Scientific} {Knowledge} {Gap} and {Reproducibility}},
-	url = {https://dl.acm.org/doi/10.1145/3701716.3715483},
-	doi = {10.1145/3701716.3715483},
-	language = {en},
-	urldate = {2026-05-19},
-	booktitle = {Companion {Proceedings} of the {ACM} on {Web} {Conference} 2025},
-	publisher = {ACM},
-	author = {Chhetri, Tek Raj and Halchenko, Yaroslav O. and Jarecka, Dorota and Trivedi, Puja and Ghosh, Satrajit S. and Ray, Patrick and Ng, Lydia},
-	month = may,
-	year = {2025},
-	pages = {924--928},
-}
-
-@misc{nastase_clustering_2015,
+@misc{nastaseClusteringCorticalSearchlights2015,
 	title = {Clustering cortical searchlights based on shared representational geometry},
 	author = {Nastase, Samuel A. and Visconti di Oleggio Castello, Matteo and Haxby, James V. and Gobbini, M. Ida and Halchenko, Yaroslav O.},
 	year = {2015},
 	note = {Published: Oral presentation at the annual meeting of the Organization for Human Brain Mapping, Honolulu, HI},
 }
 
-@misc{halchenko_converging_2014,
+@misc{halchenkoConvergingCataloguesWarehouses2014,
 	title = {Converging catalogues, warehouses, and deployment logistics into a federated 'data distribution'},
 	author = {Halchenko, Yaroslav O. and Hanke, Michael},
 	year = {2014},
 	note = {Published: Annual PI meeting of Collaborative Research in Computational Neuroscience (CRCNS) program, Tempe, AZ},
 }
 
-@misc{anna_manelis_cortical_2021,
+@misc{annamanelisCorticalMyelinMeasured2021,
 	title = {Cortical myelin measured by the {T1w}/{T2w} ratio in individuals with depressive disorders and healthy controls},
 	url = {https://openneuro.org/datasets/ds003653/versions/1.0.0},
 	doi = {10.18112/OPENNEURO.DS003653.V1.0.0},
@@ -530,7 +528,7 @@ Tweet \#BioCompute @BioComputeObj},
 	year = {2021},
 }
 
-@inproceedings{nastase_cross-modal_2016,
+@inproceedings{nastaseCrossmodalSearchlightClassification2016,
 	title = {Cross-modal searchlight classification: {Methodological} challenges and recommended solutions},
 	doi = {10.1109/PRNI.2016.7552355},
 	booktitle = {2016 {International} {Workshop} on {Pattern} {Recognition} in {Neuroimaging} ({PRNI})},
@@ -540,17 +538,27 @@ Tweet \#BioCompute @BioComputeObj},
 	pages = {1--4},
 }
 
-@misc{halchenko_dartmouth_2023,
+@article{chapmanCurrentBestPractices2020,
+	title = {Current {Best} {Practices} for {Generalizing} {Sensitive} {Species} {Occurrence} {Data}},
+	url = {https://docs.gbif.org/sensitive-species-best-practices/master/en/},
+	doi = {10.15468/DOC-5JP4-5G10},
+	abstract = {This document aims to provide best practice (or best current practice) for dealing with sensitive primary species occurrence data, and provide guidance on how to make as much data available without at the same time opening up the species to harm because data has been placed in the public domain.},
+	urldate = {2026-07-30},
+	author = {Chapman, Arthur},
+	year = {2020},
+}
+
+@misc{halchenkoDartmouthBrainImaging2023,
 	title = {Dartmouth {Brain} {Imaging} {Center} ({DBIC}) {QA} data (weekly {QA} scans etc.)},
 	copyright = {Open Data Commons Public Domain Dedication \& License 1.0},
 	url = {https://zenodo.org/record/8253053},
+	doi = {10.5281/ZENODO.8253053},
 	publisher = {Zenodo},
 	author = {Halchenko, Yaroslav O. and Kodiweera, Chandana and Sacket, Terry},
 	year = {2023},
-	doi = {10.5281/ZENODO.8253053},
 }
 
-@misc{elixir_rdmkit_community_data_2024,
+@misc{elixirrdmkitcommunityDataAnalysisBest2024,
 	title = {Data analysis best practices},
 	url = {https://rdmkit.elixir-europe.org/data_analysis},
 	urldate = {2026-04-19},
@@ -559,7 +567,7 @@ Tweet \#BioCompute @BioComputeObj},
 	note = {Published: ELIXIR Research Data Management Kit},
 }
 
-@article{poline_data_2012,
+@article{polineDataSharingNeuroimaging2012,
 	title = {Data sharing in neuroimaging research},
 	volume = {6},
 	issn = {1662-5196},
@@ -570,7 +578,7 @@ Tweet \#BioCompute @BioComputeObj},
 	year = {2012},
 }
 
-@misc{halchenko_datalad_2016,
+@misc{halchenkoDataLadDecentralizedData2016,
 	title = {{DataLad} – decentralized data distribution for consumption and sharing of scientific datasets},
 	url = {http://www.pymvpa.org/files/OHBM2016_Halchenko_datalad.pdf},
 	author = {Halchenko, Yaroslav. O and Poldrack, Benjamin and Hanke, Michael},
@@ -578,7 +586,7 @@ Tweet \#BioCompute @BioComputeObj},
 	note = {Published: Organization of Human Brain Mapping Annual Meeting, Geneva, Switzerland. Talk},
 }
 
-@article{halchenko_datalad_2021,
+@article{halchenkoDataLadDistributedSystem2021,
 	title = {{DataLad}: distributed system for joint management of code, data, and their relationship},
 	volume = {6},
 	issn = {2475-9066},
@@ -596,7 +604,7 @@ Tweet \#BioCompute @BioComputeObj},
 	pages = {3262},
 }
 
-@article{halchenko_datalad_2021-1,
+@article{halchenkoDataLadDistributedSystem2021a,
 	title = {{DataLad}: distributed system for joint management of code, data, and their relationship},
 	volume = {6},
 	issn = {2475-9066},
@@ -614,7 +622,7 @@ Tweet \#BioCompute @BioComputeObj},
 	pages = {3262},
 }
 
-@article{gebru_datasheets_2021,
+@article{gebruDatasheetsDatasets2021,
 	title = {Datasheets for datasets},
 	volume = {64},
 	issn = {0001-0782, 1557-7317},
@@ -631,7 +639,7 @@ Tweet \#BioCompute @BioComputeObj},
 	pages = {86--92},
 }
 
-@inproceedings{tille_debian_2011,
+@inproceedings{tilleDebianMedIntegrated2011,
 	address = {Luxembourg},
 	title = {Debian {Med}: {Integrated} software environment for all medical purposes based on {Debian} {GNU}/{Linux}},
 	booktitle = {Global {Telemedicine} and {eHealth} {Updates}: {Knowledge} {Resources}},
@@ -641,7 +649,7 @@ Tweet \#BioCompute @BioComputeObj},
 	year = {2011},
 }
 
-@article{poldrack_decoding_2009,
+@article{poldrackDecodingLargeScaleStructure2009,
 	title = {Decoding the {Large}-{Scale} {Structure} of {Brain} {Function} by {Classifying} {Mental} {States} {Across} {Individuals}},
 	volume = {20},
 	issn = {1467-9280},
@@ -655,14 +663,14 @@ Tweet \#BioCompute @BioComputeObj},
 	pages = {1364--1372},
 }
 
-@misc{nastase_decoding_2018,
+@misc{nastaseDecodingNeuralRepresentation2018,
 	title = {Decoding the neural representation of observed social and nonsocial human actions},
 	author = {Nastase, Samuel and Philip, Rebecca and Chauhan, Vassiki and Ma, Feilong and Taylor, Morgan and Halchenko, Yaroslav O. and Gobbini, M. Ida and Haxby, James},
 	year = {2018},
 	note = {Published: Poster presented at the annual meeting of the Organization for Human Brain Mapping, Singapore},
 }
 
-@article{hanson_dense_2007,
+@article{hansonDenseModeClustering2007,
 	title = {Dense mode clustering in brain maps},
 	volume = {25},
 	issn = {0730-725X},
@@ -676,7 +684,7 @@ Tweet \#BioCompute @BioComputeObj},
 	pages = {1249--62},
 }
 
-@article{rorden_dicom_2025,
+@article{rordenDICOMDatasetsReproducible2025,
 	title = {{DICOM} datasets for reproducible neuroimaging research across manufacturers and software versions},
 	volume = {12},
 	issn = {2052-4463},
@@ -689,14 +697,25 @@ Tweet \#BioCompute @BioComputeObj},
 	year = {2025},
 }
 
-@misc{halchenko_duecredit_2016,
+@misc{unitedstatescensusbureauDisseminationAccessInnovation2025,
+	title = {Dissemination and {Access}—{Innovation} and {Research}},
+	url = {https://www.census.gov/topics/research/dissemination-access.html},
+	language = {en-US},
+	urldate = {2026-07-30},
+	journal = {United States Census Bureau},
+	author = {{United States Census Bureau}},
+	month = jan,
+	year = {2025},
+}
+
+@misc{halchenkoDueCreditAutomagicallyCollect2016,
 	title = {{DueCredit} - automagically collect citations for software, methods, and data you use},
 	author = {Halchenko, Yaroslav O. and Visconti di Oleggio Castello, Matteo},
 	year = {2016},
 	note = {Published: Organization of Human Brain Mapping Annual Meeting, Geneva, Switzerland. Talk},
 }
 
-@misc{ruslan_kuprieiev_dvc_2026,
+@misc{ruslankuprieievDVCDataVersion2026,
 	title = {{DVC}: {Data} {Version} {Control} - {Git} for {Data} \& {Models}},
 	copyright = {Apache License 2.0},
 	shorttitle = {{DVC}},
@@ -732,7 +751,7 @@ Full Changelog: https://github.com/treeverse/dvc/compare/3.67.0...3.67.1},
 	keywords = {ai, collaboration, data-science, data-version-control, developer-tools, git, machine-learning, python, reproducibility},
 }
 
-@misc{casanova_eduwrench_2023,
+@misc{casanovaEduWrenchPedagogicModules2023,
 	title = {{EduWrench}: {Pedagogic} {Modules} for {Parallel} and {Distributed} {Computing}},
 	url = {https://eduwrench.ics.hawaii.edu/},
 	urldate = {2026-04-19},
@@ -741,7 +760,7 @@ Full Changelog: https://github.com/treeverse/dvc/compare/3.67.0...3.67.1},
 	note = {Published: Online teaching platform, University of Hawai‘ i},
 }
 
-@inproceedings{claerbout_electronic_1992,
+@inproceedings{claerboutElectronicDocumentsGive1992,
 	title = {Electronic documents give reproducible research a new meaning},
 	url = {http://library.seg.org/doi/abs/10.1190/1.1822162},
 	doi = {10.1190/1.1822162},
@@ -755,7 +774,7 @@ Full Changelog: https://github.com/treeverse/dvc/compare/3.67.0...3.67.1},
 	pages = {601--604},
 }
 
-@misc{entire_entire_2026,
+@misc{entireEntireCLIGit2026,
 	title = {Entire {CLI}: {Git} observability layer that captures {AI} agent sessions as checkpoints alongside commits},
 	url = {https://github.com/entireio/cli},
 	urldate = {2026-04-19},
@@ -764,7 +783,7 @@ Full Changelog: https://github.com/treeverse/dvc/compare/3.67.0...3.67.1},
 	note = {Published: Software, GitHub repository},
 }
 
-@article{kennedy_everything_2019,
+@article{kennedyEverythingMattersReproNim2019,
 	title = {Everything {Matters}: {The} {ReproNim} {Perspective} on {Reproducible} {Neuroimaging}},
 	volume = {13},
 	issn = {1662-5196},
@@ -777,7 +796,7 @@ Full Changelog: https://github.com/treeverse/dvc/compare/3.67.0...3.67.1},
 	year = {2019},
 }
 
-@article{szinte_eye-tracking-bids_2026,
+@article{szinteEyeTrackingBIDSBrainImaging2026,
 	title = {Eye-{Tracking}-{BIDS}: the {Brain} {Imaging} {Data} {Structure} extended to gaze position and pupil data},
 	url = {https://www.biorxiv.org/content/early/2026/02/05/2026.02.03.703514},
 	doi = {10.64898/2026.02.03.703514},
@@ -789,7 +808,7 @@ Full Changelog: https://github.com/treeverse/dvc/compare/3.67.0...3.67.1},
 	note = {\_eprint: https://www.biorxiv.org/content/early/2026/02/05/2026.02.03.703514.full.pdf},
 }
 
-@article{goble_fair_2020,
+@article{gobleFAIRComputationalWorkflows2020,
 	title = {{FAIR} {Computational} {Workflows}},
 	volume = {2},
 	issn = {2641-435X},
@@ -806,7 +825,7 @@ Full Changelog: https://github.com/treeverse/dvc/compare/3.67.0...3.67.1},
 	pages = {108--121},
 }
 
-@article{de_smedt_fair_2020,
+@article{desmedtFAIRDigitalObjects2020,
 	title = {{FAIR} {Digital} {Objects} for {Science}: {From} {Data} {Pieces} to {Actionable} {Knowledge} {Units}},
 	volume = {8},
 	issn = {2304-6775},
@@ -824,7 +843,7 @@ Full Changelog: https://github.com/treeverse/dvc/compare/3.67.0...3.67.1},
 	pages = {21},
 }
 
-@article{wagner_fairly_2022,
+@article{wagnerFAIRlyBigFramework2022,
 	title = {{FAIRly} big: {A} framework for computationally reproducible processing of large-scale data},
 	volume = {9},
 	issn = {2052-4463},
@@ -843,7 +862,7 @@ Full Changelog: https://github.com/treeverse/dvc/compare/3.67.0...3.67.1},
 	pages = {80},
 }
 
-@misc{halchenko_fantastic_2019,
+@misc{halchenkoFantasticContainersHow2019,
 	title = {Fantastic containers and how to tame them},
 	url = {https://github.com/ReproNim/artwork/raw/master/posters/ohbm2019-containers.pdf},
 	author = {Halchenko, Yaroslav O. and Meyer, Kyle and Jarecka, Dorota,  and Ghosh, Satra and Kaczmarzyk, Jakub,  and Hanke, Michael},
@@ -851,14 +870,14 @@ Full Changelog: https://github.com/treeverse/dvc/compare/3.67.0...3.67.1},
 	note = {Published: Poster presented at the annual meeting of the Organization for Human Brain Mapping, Rome, Italy},
 }
 
-@misc{visconti_di_oleggio_castello_finding_2015,
+@misc{viscontidioleggiocastelloFindingCorticalPatches2015,
 	title = {Finding cortical patches of shared representations: a comparison of clustering algorithms on representational geometries, and the effect of cross-validation to reduce physiological noise},
 	author = {Visconti di Oleggio Castello, Matteo and Nastase, Samuel A. and Gobbini, M. Ida and Haxby, James V. and Halchenko, Yaroslav O.},
 	year = {2015},
 	note = {Published: Poster presented at the annual meeting of the Society for Neuroscience, Chicago, IL},
 }
 
-@article{halchenko_four_2015,
+@article{halchenkoFourAspectsMake2015,
 	title = {Four aspects to make science open "by design" and not as an after-thought},
 	volume = {4},
 	doi = {10.1186/s13742-015-0072-7},
@@ -868,7 +887,7 @@ Full Changelog: https://github.com/treeverse/dvc/compare/3.67.0...3.67.1},
 	year = {2015},
 }
 
-@article{fowler_frictionless_2018,
+@article{fowlerFrictionlessDataMaking2018,
 	title = {Frictionless {Data}: {Making} {Research} {Data} {Quality} {Visible}},
 	volume = {12},
 	copyright = {http://creativecommons.org/licenses/by/4.0},
@@ -886,7 +905,7 @@ Full Changelog: https://github.com/treeverse/dvc/compare/3.67.0...3.67.1},
 	pages = {274--285},
 }
 
-@inproceedings{halchenko_fusion_2004,
+@inproceedings{halchenkoFusionFunctionalBrain2004a,
 	title = {Fusion of {Functional} {Brain} {Imaging} {Modalities} using {L}-{Norms} {Signal} {Reconstruction}},
 	booktitle = {Proceedings of the {Annual} {Meeting} of the {Cognitive} {Neuroscience} {Society}},
 	author = {Halchenko, Y. O. and Hanson, S. J. and Pearlmutter, B. A.},
@@ -894,7 +913,7 @@ Full Changelog: https://github.com/treeverse/dvc/compare/3.67.0...3.67.1},
 	keywords = {EEG, fMRI, fusion},
 }
 
-@article{halchenko_fusion_2004-1,
+@article{halchenkoFusionFunctionalBrain2004,
 	title = {Fusion of functional brain imaging modalities via linear programming},
 	volume = {48},
 	url = {http://www.onerussian.com/Sci/pubs/lpnfsi2003.pdf},
@@ -905,18 +924,18 @@ Full Changelog: https://github.com/treeverse/dvc/compare/3.67.0...3.67.1},
 	pages = {102--4},
 }
 
-@misc{taylor_go_2025,
+@misc{taylorGoFigureTransparency2025,
 	title = {Go {Figure}: {Transparency} in neuroscience images preserves context and clarifies interpretation},
 	copyright = {Creative Commons Attribution 4.0 International},
 	url = {https://arxiv.org/abs/2504.07824},
+	doi = {10.48550/ARXIV.2504.07824},
 	publisher = {arXiv},
 	author = {Taylor, Paul A. and Aggarwal, Himanshu and Bandettini, Peter and Barilari, Marco and Bright, Molly and Caballero-Gaudes, Cesar and Calhoun, Vince and Chakravarty, Mallar and Devenyi, Gabriel and Evans, Jennifer and Garza-Villarreal, Eduardo and Rasgado-Toledo, Jalil and Gau, Remi and Glen, Daniel and Goebel, Rainer and Gonzalez-Castillo, Javier and Gulban, Omer Faruk and Halchenko, Yaroslav and Handwerker, Daniel and Hanayik, Taylor and Lauren, Peter and Leopold, David and Lerch, Jason and Mathys, Christian and McCarthy, Paul and McLeod, Anke and Mejia, Amanda and Moia, Stefano and Nichols, Thomas and Pernet, Cyril and Pessoa, Luiz and Pfleiderer, Bettina and Rajendra, Justin and Reyes, Laura and Reynolds, Richard and Roopchansingh, Vinai and Rorden, Chris and Russ, Brian and Sundermann, Benedikt and Thirion, Bertrand and Torrisi, Salvatore and Chen, Gang},
 	year = {2025},
-	doi = {10.48550/ARXIV.2504.07824},
 	keywords = {FOS: Biological sciences, Neurons and Cognition (q-bio.NC)},
 }
 
-@article{wilson_good_2017,
+@article{wilsonGoodEnoughPractices2017,
 	title = {Good enough practices in scientific computing},
 	volume = {13},
 	issn = {1553-7358},
@@ -933,7 +952,7 @@ Full Changelog: https://github.com/treeverse/dvc/compare/3.67.0...3.67.1},
 	pages = {e1005510},
 }
 
-@misc{baker_guidelines_2026,
+@misc{bakerGuidelinesReproducibleResearch2026,
 	title = {Guidelines for {Reproducible} {Research} ({STAMPED})},
 	url = {https://www.youtube.com/watch?v=8NTWKHer5Zo},
 	urldate = {2026-04-19},
@@ -943,23 +962,7 @@ Full Changelog: https://github.com/treeverse/dvc/compare/3.67.0...3.67.1},
 	note = {Published: Talk presented at the Virtual BBQS Workshop, Center for Open Neuroscience},
 }
 
-@article{halchenko_heudiconv_2024,
-	title = {{HeuDiConv} — flexible {DICOM} conversion into structureddirectory layouts},
-	volume = {9},
-	copyright = {http://creativecommons.org/licenses/by/4.0/},
-	issn = {2475-9066},
-	url = {https://joss.theoj.org/papers/10.21105/joss.05839},
-	doi = {10.21105/joss.05839},
-	number = {99},
-	urldate = {2025-08-14},
-	journal = {Journal of Open Source Software},
-	author = {Halchenko, Yaroslav O. and Goncalves, Mathias and Ghosh, Satrajit and Velasco, Pablo and Visconti Di Oleggio Castello, Matteo and Salo, Taylor and Wodder, John T. and Hanke, Michael and Sadil, Patrick and Gorgolewski, Krzysztof Jacek and Ioanas, Horea-Ioan and Rorden, Chris and Hendrickson, Timothy J. and Dayan, Michael and Houlihan, Sean Dae and Kent, James and Strauss, Ted and Lee, John and To, Isaac and Markiewicz, Christopher J. and Lukas, Darren and Butler, Ellyn R. and Thompson, Todd and Termenon, Maite and Smith, David V. and Macdonald, Austin and Kennedy, David N.},
-	month = jul,
-	year = {2024},
-	pages = {5839},
-}
-
-@article{halchenko_heudiconv_2024-1,
+@article{halchenkoHeuDiConvFlexibleDICOM2024,
 	title = {{HeuDiConv} — flexible {DICOM} conversion into structureddirectory layouts},
 	volume = {9},
 	copyright = {http://creativecommons.org/licenses/by/4.0/},
@@ -976,7 +979,23 @@ Full Changelog: https://github.com/treeverse/dvc/compare/3.67.0...3.67.1},
 	pages = {5839},
 }
 
-@article{connolly_how_2016,
+@article{halchenkoHeuDiConvFlexibleDICOM2024a,
+	title = {{HeuDiConv} — flexible {DICOM} conversion into structureddirectory layouts},
+	volume = {9},
+	copyright = {http://creativecommons.org/licenses/by/4.0/},
+	issn = {2475-9066},
+	url = {https://joss.theoj.org/papers/10.21105/joss.05839},
+	doi = {10.21105/joss.05839},
+	number = {99},
+	urldate = {2025-08-14},
+	journal = {Journal of Open Source Software},
+	author = {Halchenko, Yaroslav O. and Goncalves, Mathias and Ghosh, Satrajit and Velasco, Pablo and Visconti Di Oleggio Castello, Matteo and Salo, Taylor and Wodder, John T. and Hanke, Michael and Sadil, Patrick and Gorgolewski, Krzysztof Jacek and Ioanas, Horea-Ioan and Rorden, Chris and Hendrickson, Timothy J. and Dayan, Michael and Houlihan, Sean Dae and Kent, James and Strauss, Ted and Lee, John and To, Isaac and Markiewicz, Christopher J. and Lukas, Darren and Butler, Ellyn R. and Thompson, Todd and Termenon, Maite and Smith, David V. and Macdonald, Austin and Kennedy, David N.},
+	month = jul,
+	year = {2024},
+	pages = {5839},
+}
+
+@article{connollyHowHumanBrain2016,
 	title = {How the human brain represents perceived dangerousness or "predacity" of animals},
 	volume = {36},
 	issn = {1529-2401},
@@ -990,14 +1009,14 @@ Full Changelog: https://github.com/treeverse/dvc/compare/3.67.0...3.67.1},
 	pages = {5373--5384},
 }
 
-@misc{poline_how_2015,
+@misc{polineHowMakeBrain2015,
 	title = {How to make brain imaging research efficient and reproducible: building software and standards},
 	author = {Poline, Jean Baptiste and Das, Samir and Keator, David and Gorgolewski, Krzysztof and Auer, Tibor and Chen, Gang and Craddock, Cameron and Flandin, Guillaume and Ghosh, Satrajit and Halchenko, Yaroslav O. and Hanke, Michael and Haselgrove, Christian and Helmer, Karl and Jenkinson, Mark and Klein, Arno and Marcus, Daniel and Margulies, Daniel and Maumet, Camille and Michel, Franck and Nichols, Nolan and Nichols, Thomas and Poldrack, Russell and Reynolds, Richard and Saad, Ziad S. and Schmah, Tanya and Steffener, Jason and Turner, Jessica and Erp, Theo van and Horn, John Van and Das, Samir and Kennedy, David},
 	year = {2015},
 	note = {Published: Organization of Human Brain Mapping Annual Meeting, Honolulu HI, USA. Poster},
 }
 
-@article{abernathey_icechunk_2024,
+@article{abernatheyIcechunkOpenSourceTransactional2024,
 	title = {Icechunk: {An} {Open}-{Source} {Transactional} {Storage} {Engine} for {Zarr}},
 	copyright = {Creative Commons Attribution 4.0 International},
 	shorttitle = {Icechunk},
@@ -1032,7 +1051,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	year = {2024},
 }
 
-@incollection{tymchenko_image_1998,
+@incollection{tymchenkoImageSegmentationBasis1998,
 	address = {Vinnytsya, Ukraine},
 	title = {Image {Segmentation} on the basis of spatial connected features},
 	volume = {4},
@@ -1043,14 +1062,14 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {39--43},
 }
 
-@misc{hanke_improving_2010,
+@misc{hankeImprovingEfficiencyCognitive2010,
 	title = {Improving efficiency in cognitive neuroscience research with {NeuroDebian}},
 	author = {Hanke, Michael and Halchenko, Yaroslav O. and Haxby, James V. and Pollmann, Stefan},
 	year = {2010},
 	note = {Published: Annual meeting of the Cognitive Neuroscience Society, Montreal, Canada},
 }
 
-@article{hanke_defense_2021,
+@article{hankeDefenseDecentralizedResearch2021,
 	title = {In defense of decentralized research data management},
 	volume = {0},
 	copyright = {http://creativecommons.org/licenses/by/4.0},
@@ -1069,14 +1088,14 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {000010151520200037},
 }
 
-@misc{halchenko_incorrect_2012,
+@misc{halchenkoIncorrectProbabilitiesHarvardOxfordsub2012,
 	title = {Incorrect probabilities in {Harvard}-{Oxford}-sub {Left} hemisphere},
 	url = {https://www.jiscmail.ac.uk/cgi-bin/webadmin?A2=fsl;e46ecc4c.1210},
 	author = {Halchenko, Yaroslav O.},
 	year = {2012},
 }
 
-@article{barker_introducing_2022,
+@article{barkerIntroducingFAIRPrinciples2022,
 	title = {Introducing the {FAIR} {Principles} for research software},
 	volume = {9},
 	issn = {2052-4463},
@@ -1094,7 +1113,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {622},
 }
 
-@misc{halchenko_investigation_2012,
+@misc{halchenkoInvestigationFamiliarFace2012,
 	title = {Investigation of the familiar face recognition model},
 	url = {http://haxbylab.dartmouth.edu/publications/HGG+12_sfn12_famfaces.png},
 	author = {Halchenko, Y. O. and Gors, J. and Guntupalli, J. S. and Haxby, J. V. and Gobbini, M. I.},
@@ -1102,7 +1121,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	note = {Published: Society for Neuroscience Annual Meeting, New Orleans. Poster},
 }
 
-@article{kennedy_iq_2021,
+@article{kennedyIQTypicalDevelopment2021,
 	title = {{IQ} in {Typical} {Development}: {A} {Mega}-{Analysis} of the {Historical} {Literature}},
 	volume = {89},
 	url = {https://doi.org/10.1016/j.biopsych.2021.02.385},
@@ -1115,9 +1134,10 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {S150},
 }
 
-@techreport{bradner_key_1997,
+@techreport{bradnerKeyWordsUse1997,
 	title = {Key words for use in {RFCs} to {Indicate} {Requirement} {Levels}},
 	url = {https://www.rfc-editor.org/info/rfc2119},
+	doi = {10.17487/rfc2119},
 	language = {en},
 	number = {RFC2119},
 	urldate = {2026-03-06},
@@ -1125,11 +1145,10 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	author = {Bradner, S.},
 	month = mar,
 	year = {1997},
-	doi = {10.17487/rfc2119},
 	pages = {RFC2119},
 }
 
-@misc{mitchener_kosmos_2025,
+@misc{mitchenerKosmosAIScientist2025,
 	title = {Kosmos: {An} {AI} {Scientist} for {Autonomous} {Discovery}},
 	shorttitle = {Kosmos},
 	url = {http://arxiv.org/abs/2511.02824},
@@ -1144,21 +1163,21 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	keywords = {Computer Science - Artificial Intelligence},
 }
 
-@misc{nastase_localizing_2016,
+@misc{nastaseLocalizingFunctionalRegions2016,
 	title = {Localizing functional regions of interest based on responses to dynamic naturalistic stimuli},
 	author = {Nastase, Samuel A. and Guntupalli, J. Swaroop and Haxby, James V. and Halchenko, Yaroslav O.},
 	year = {2016},
 	note = {Published: Poster presented at the annual meeting of the Society for Neuroscience, Chicago, IL},
 }
 
-@misc{hanke_metadata_2018,
+@misc{hankeMetaDataWorkflowManagement2018,
 	title = {({Meta}){Data} and workflow management for your most important work and your daily routine},
 	author = {Hanke, Michael and Meyer, Kyle and Poldrack, Benjamin and Halchenko, Yaroslav O.},
 	year = {2018},
 	note = {Published: Poster presented at the INCF annual meeting Neuroinformatics 2018, Montreal, Canada},
 }
 
-@inproceedings{timchenko_method_2000,
+@inproceedings{timchenkoMethodImageCoordinate2000,
 	title = {Method for image coordinate definition on extended laser paths},
 	volume = {4148:1},
 	url = {http://link.aip.org/link/?PSI/4148/19/1},
@@ -1168,11 +1187,10 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	author = {Timchenko, L. I. and Kutaev, Y. F. and Gertsiy, A. A. and Halchenko, Y. O. and Zahoruiko, L. V. and Mansur, T.},
 	editor = {Gurevich, S. B. and Nazarchuk, Z. T. and Muravsky, L. I.},
 	year = {2000},
-	note = {event-place: Lviv, Ukraine},
 	pages = {19--26},
 }
 
-@article{crusoe_methods_2022,
+@article{crusoeMethodsIncludedStandardizing2022,
 	title = {Methods included: standardizing computational reuse and portability with the {Common} {Workflow} {Language}},
 	volume = {65},
 	issn = {0001-0782, 1557-7317},
@@ -1190,7 +1208,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {54--63},
 }
 
-@article{bourget_microscopy-bids_2022,
+@article{bourgetMicroscopyBIDSExtensionBrain2022,
 	title = {Microscopy-{BIDS}: {An} {Extension} to the {Brain} {Imaging} {Data} {Structure} for {Microscopy} {Data}},
 	volume = {16},
 	issn = {1662-453X},
@@ -1211,7 +1229,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {871228},
 }
 
-@inproceedings{mitchell_model_2019,
+@inproceedings{mitchellModelCardsModel2019,
 	address = {Atlanta GA USA},
 	title = {Model {Cards} for {Model} {Reporting}},
 	isbn = {978-1-4503-6125-5},
@@ -1227,7 +1245,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {220--229},
 }
 
-@misc{heejung_jung_mriqc_2025,
+@misc{heejungjungMRIQCDerivativesSpaceTop2025,
 	title = {{MRIQC} {Derivatives} for {SpaceTop}},
 	url = {https://openneuro.org/datasets/ds006692/versions/1.0.0},
 	doi = {10.18112/OPENNEURO.DS006692.V1.0.0},
@@ -1237,7 +1255,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	year = {2025},
 }
 
-@article{bouchard_mrs-bids_2025,
+@article{bouchardMRSBIDSExtensionBrain2025,
 	title = {{MRS}-{BIDS}, an extension to the {Brain} {Imaging} {Data} {Structure} for magnetic resonance spectroscopy},
 	volume = {12},
 	issn = {2052-4463},
@@ -1252,7 +1270,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {1384},
 }
 
-@article{bouchard_mrs-bids_2025-1,
+@article{bouchardMRSBIDSExtensionBrain2025a,
 	title = {{MRS}-{BIDS}, an extension to the {Brain} {Imaging} {Data} {Structure} for magnetic resonance spectroscopy},
 	volume = {12},
 	issn = {2052-4463},
@@ -1267,7 +1285,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {1384},
 }
 
-@article{wagner_multimatch-gaze_2019,
+@article{wagnerMultimatchgazeMultiMatchAlgorithm2019,
 	title = {multimatch-gaze: {The} {MultiMatch} algorithm for gaze path comparison in {Python}},
 	volume = {4},
 	url = {https://doi.org/10.21105/joss.01525},
@@ -1279,7 +1297,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {1525},
 }
 
-@article{nastase_narratives_2020,
+@article{nastaseNarrativesFMRIData2020,
 	title = {Narratives: {fMRI} data for evaluating models of naturalistic language comprehension},
 	url = {https://doi.org/10.1101/2020.12.23.424091},
 	doi = {10.1101/2020.12.23.424091},
@@ -1288,7 +1306,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	year = {2020},
 }
 
-@misc{nastase_neural_2019,
+@misc{nastaseNeuralResponsesNaturalistic2019,
 	title = {Neural responses to naturalistic clips of behaving animals in two different task contexts},
 	url = {https://openneuro.org/datasets/ds000233/versions/1.0.1},
 	doi = {10.18112/OPENNEURO.DS000233.V1.0.1},
@@ -1298,14 +1316,14 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	year = {2019},
 }
 
-@misc{halchenko_neurodebian_2013,
+@misc{halchenkoNeuroDebianDisjointTools2013,
 	title = {{NeuroDebian}: from disjoint tools and data to robust turnkey platform for neuroimaging and beyond},
 	url = {http://www.youtube.com/watch?v=WhUrTRuMoFs},
 	author = {Halchenko, Yaroslav O.},
 	year = {2013},
 }
 
-@article{renton_neurodesk_2024,
+@article{rentonNeurodeskAccessibleFlexible2024,
 	title = {Neurodesk: an accessible, flexible and portable data analysis environment for reproducible neuroimaging},
 	volume = {21},
 	issn = {1548-7105},
@@ -1319,22 +1337,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {804--808},
 }
 
-@article{ioanas_neuroimaging_2024,
-	title = {Neuroimaging article reexecution and reproduction assessment system},
-	volume = {18},
-	issn = {1662-5196},
-	url = {https://www.frontiersin.org/articles/10.3389/fninf.2024.1376022/full},
-	doi = {10.3389/fninf.2024.1376022},
-	abstract = {The value of research articles is increasingly contingent on complex data analysis results which substantiate their claims. Compared to data production, data analysis more readily lends itself to a higher standard of transparency and repeated operator-independent execution. This higher standard can be approached via fully reexecutable research outputs, which contain the entire instruction set for automatic end-to-end generation of an entire article from the earliest feasible provenance point. In this study, we make use of a peer-reviewed neuroimaging article which provides complete but fragile reexecution instructions, as a starting point to draft a new reexecution system which is both robust and portable. We render this system modular as a core design aspect, so that reexecutable article code, data, and environment specifications could potentially be substituted or adapted. In conjunction with this system, which forms the demonstrative product of this study, we detail the core challenges with full article reexecution and specify a number of best practices which permitted us to mitigate them. We further show how the capabilities of our system can subsequently be used to provide reproducibility assessments, both via simple statistical metrics and by visually highlighting divergent elements for human inspection. We argue that fully reexecutable articles are thus a feasible best practice, which can greatly enhance the understanding of data analysis variability and the trust in results. Lastly, we comment at length on the outlook for reexecutable research outputs and encourage re-use and derivation of the system produced herein.},
-	urldate = {2025-08-14},
-	journal = {Frontiers in Neuroinformatics},
-	author = {Ioanas, Horea-Ioan and Macdonald, Austin and Halchenko, Yaroslav O.},
-	month = jul,
-	year = {2024},
-	pages = {1376022},
-}
-
-@article{ioanas_neuroimaging_2024-1,
+@article{ioanasNeuroimagingArticleReexecution2024,
 	title = {Neuroimaging article reexecution and reproduction assessment system},
 	volume = {18},
 	issn = {1662-5196},
@@ -1349,7 +1352,22 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {1376022},
 }
 
-@article{hanke_neuroscience_2011,
+@article{ioanasNeuroimagingArticleReexecution2024a,
+	title = {Neuroimaging article reexecution and reproduction assessment system},
+	volume = {18},
+	issn = {1662-5196},
+	url = {https://www.frontiersin.org/articles/10.3389/fninf.2024.1376022/full},
+	doi = {10.3389/fninf.2024.1376022},
+	abstract = {The value of research articles is increasingly contingent on complex data analysis results which substantiate their claims. Compared to data production, data analysis more readily lends itself to a higher standard of transparency and repeated operator-independent execution. This higher standard can be approached via fully reexecutable research outputs, which contain the entire instruction set for automatic end-to-end generation of an entire article from the earliest feasible provenance point. In this study, we make use of a peer-reviewed neuroimaging article which provides complete but fragile reexecution instructions, as a starting point to draft a new reexecution system which is both robust and portable. We render this system modular as a core design aspect, so that reexecutable article code, data, and environment specifications could potentially be substituted or adapted. In conjunction with this system, which forms the demonstrative product of this study, we detail the core challenges with full article reexecution and specify a number of best practices which permitted us to mitigate them. We further show how the capabilities of our system can subsequently be used to provide reproducibility assessments, both via simple statistical metrics and by visually highlighting divergent elements for human inspection. We argue that fully reexecutable articles are thus a feasible best practice, which can greatly enhance the understanding of data analysis variability and the trust in results. Lastly, we comment at length on the outlook for reexecutable research outputs and encourage re-use and derivation of the system produced herein.},
+	urldate = {2025-08-14},
+	journal = {Frontiers in Neuroinformatics},
+	author = {Ioanas, Horea-Ioan and Macdonald, Austin and Halchenko, Yaroslav O.},
+	month = jul,
+	year = {2024},
+	pages = {1376022},
+}
+
+@article{hankeNeuroscienceRunsGNU2011,
 	title = {Neuroscience {Runs} on {GNU}/{Linux}},
 	volume = {5},
 	issn = {1662-5196},
@@ -1362,7 +1380,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {8},
 }
 
-@article{di_tommaso_nextflow_2017,
+@article{ditommasoNextflowEnablesReproducible2017,
 	title = {Nextflow enables reproducible computational workflows},
 	volume = {35},
 	issn = {1087-0156, 1546-1696},
@@ -1378,21 +1396,21 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {316--319},
 }
 
-@misc{travers_niceman_2018,
+@misc{traversNICEMANNeuroImagingComputational2018,
 	title = {{NICEMAN}: {NeuroImaging} {Computational} {Environments} {Manager}},
 	author = {Travers, Matthew and Buccigrossi, Robert and Haselgrove, Christian and Meyer, Kyle and Halchenko, Yaroslav O.},
 	year = {2018},
 	note = {Published: Poster presented at the annual meeting of the Organization for Human Brain Mapping, Singapore},
 }
 
-@misc{ghosh_nidm-workflow_2015,
+@misc{ghoshNIDMWorkflowEvolutionProvenance2015,
 	title = {{NIDM}-{Workflow} - {The} {Evolution} of {Provenance} in {Neuroimaging}},
 	author = {Ghosh, Satrajit and Auer, Tibor and Gorgolewski, Krzysztof and Halchenko, Yaroslav O. and Hanke, Michael and Flandin, Guillaume and Nichols, Nolan and Poldrack, Russell and Horn, John Van and Marcus, Daniel and Keator, David},
 	year = {2015},
 	note = {Published: Organization of Human Brain Mapping Annual Meeting, Honolulu HI, USA. Poster},
 }
 
-@article{gorgolewski_nipype_2011,
+@article{gorgolewskiNipypeFlexibleLightweight2011,
 	title = {Nipype: a flexible, lightweight and extensible neuroimaging data processing framework in python},
 	volume = {5},
 	issn = {1662-5196},
@@ -1408,17 +1426,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {13},
 }
 
-@article{moore_ome-zarr_2023,
-	title = {{OME}-{Zarr}: a cloud-optimized bioimaging file format with international community support},
-	url = {https://doi.org/10.1101/2023.02.17.528834},
-	doi = {10.1101/2023.02.17.528834},
-	journal = {bioRxiv},
-	author = {Moore, Josh and Basurto-Lozada, Daniela and Besson, Sébastien and Bogovic, John and Brown, Eva M. and Burel, Jean-Marie and Medeiros, Gustavo de and Diel, Erin E. and Gault, David and Ghosh, Satrajit S. and Gold, Ilan and Halchenko, Yaroslav O. and Hartley, Matthew and Horsfall, Dave and Keller, Mark S. and Kittisopikul, Mark and Kovacs, Gabor and Yoldaş, Aybüke Küpcü and Villegeorges, Albane le Tournoulx de la and Li, Tong and Liberali, Prisca and Linkert, Melissa and Lindner, Dominik and Lüthi, Joel and Maitin-Shepard, Jeremy and Manz, Trevor and McCormick, Matthew and Mohamed, Khaled and Moore, William and Özdemir, Bugra and Pape, Constantin and Pelkmans, Lucas and Prete, Martin and Pietzsch, Tobias and Preibisch, Stephan and Rzepka, Norman and Stirling, David R. and Striebel, Jonathan and Tischer, Christian and Toloudis, Daniel and Walczysko, Petr and Watson, Alan M. and Wong, Frances and Yamauchi, Kevin A. and Bayraktar, Omer and Haniffa, Muzlifah and Saalfeld, Stephan and Swedlow, Jason R.},
-	month = feb,
-	year = {2023},
-}
-
-@article{moore_ome-zarr_2023-1,
+@article{mooreOMEZarrCloudoptimizedBioimaging2023,
 	title = {{OME}-{Zarr}: a cloud-optimized bioimaging file format with international community support},
 	url = {https://doi.org/10.1007/s00418-023-02209-1},
 	doi = {10.1007/s00418-023-02209-1},
@@ -1428,7 +1436,26 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	year = {2023},
 }
 
-@article{niso_open_2022,
+@article{mooreOMEZarrCloudoptimizedBioimaging2023a,
+	title = {{OME}-{Zarr}: a cloud-optimized bioimaging file format with international community support},
+	url = {https://doi.org/10.1101/2023.02.17.528834},
+	doi = {10.1101/2023.02.17.528834},
+	journal = {bioRxiv},
+	author = {Moore, Josh and Basurto-Lozada, Daniela and Besson, Sébastien and Bogovic, John and Brown, Eva M. and Burel, Jean-Marie and Medeiros, Gustavo de and Diel, Erin E. and Gault, David and Ghosh, Satrajit S. and Gold, Ilan and Halchenko, Yaroslav O. and Hartley, Matthew and Horsfall, Dave and Keller, Mark S. and Kittisopikul, Mark and Kovacs, Gabor and Yoldaş, Aybüke Küpcü and Villegeorges, Albane le Tournoulx de la and Li, Tong and Liberali, Prisca and Linkert, Melissa and Lindner, Dominik and Lüthi, Joel and Maitin-Shepard, Jeremy and Manz, Trevor and McCormick, Matthew and Mohamed, Khaled and Moore, William and Özdemir, Bugra and Pape, Constantin and Pelkmans, Lucas and Prete, Martin and Pietzsch, Tobias and Preibisch, Stephan and Rzepka, Norman and Stirling, David R. and Striebel, Jonathan and Tischer, Christian and Toloudis, Daniel and Walczysko, Petr and Watson, Alan M. and Wong, Frances and Yamauchi, Kevin A. and Bayraktar, Omer and Haniffa, Muzlifah and Saalfeld, Stephan and Swedlow, Jason R.},
+	month = feb,
+	year = {2023},
+}
+
+@article{nisoOpenReproducibleNeuroimaging2022,
+	title = {Open and reproducible neuroimaging: from study inception to publication},
+	url = {https://doi.org/10.31219/osf.io/pu5vb},
+	doi = {10.31219/osf.io/pu5vb},
+	author = {Niso, Guiomar and Botvinik-Nezer, Rotem and Appelhoff, Stefan and Vega, Alejandro De La and Esteban, Oscar and Etzel, Joset A. and Finc, Karolina and Ganz, Melanie and Gau, Remi and Halchenko, Yaroslav O. and Herholz, Peer and Karakuzu, Agah and Keator, David and MAUMET, Camille and Markiewicz, Christopher Johnson and Pernet, Cyril R. and Pestilli, Franco and Queder, Nazek and Schmitt, Tina and Sójka, Weronika and Wagner, Adina Svenja and Whitaker, Kirstie Jane and Rieger, Jochem},
+	month = apr,
+	year = {2022},
+}
+
+@article{nisoOpenReproducibleNeuroimaging2022a,
 	title = {Open and reproducible neuroimaging: {From} study inception to publication},
 	volume = {263},
 	issn = {10538119},
@@ -1444,16 +1471,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {119623},
 }
 
-@article{niso_open_2022-1,
-	title = {Open and reproducible neuroimaging: from study inception to publication},
-	url = {https://doi.org/10.31219/osf.io/pu5vb},
-	doi = {10.31219/osf.io/pu5vb},
-	author = {Niso, Guiomar and Botvinik-Nezer, Rotem and Appelhoff, Stefan and Vega, Alejandro De La and Esteban, Oscar and Etzel, Joset A. and Finc, Karolina and Ganz, Melanie and Gau, Remi and Halchenko, Yaroslav O. and Herholz, Peer and Karakuzu, Agah and Keator, David and MAUMET, Camille and Markiewicz, Christopher Johnson and Pernet, Cyril R. and Pestilli, Franco and Queder, Nazek and Schmitt, Tina and Sójka, Weronika and Wagner, Adina Svenja and Whitaker, Kirstie Jane and Rieger, Jochem},
-	month = apr,
-	year = {2022},
-}
-
-@article{halchenko_open_2012,
+@article{halchenkoOpenNotEnough2012,
 	title = {Open is not enough. {Let}'s take the next step: {An} integrated, community-driven computing platform for neuroscience},
 	volume = {6},
 	issn = {1662-5196},
@@ -1464,7 +1482,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	year = {2012},
 }
 
-@misc{wang_open_2026,
+@misc{wangOpenNeuroinformaticsInfrastructure2026,
 	title = {Open neuroinformatics infrastructure ecosystem for federated multisite studies},
 	copyright = {http://creativecommons.org/licenses/by/4.0/},
 	url = {http://biorxiv.org/lookup/doi/10.64898/2026.04.30.721944},
@@ -1479,7 +1497,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	year = {2026},
 }
 
-@misc{center_for_open_science_open_2023,
+@misc{centerforopenscienceOpenScienceBadges2023,
 	title = {Open {Science} {Badges}},
 	url = {https://www.cos.io/initiatives/badges},
 	urldate = {2026-04-19},
@@ -1488,7 +1506,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	note = {Published: Center for Open Science initiative},
 }
 
-@article{foster_open_2017,
+@article{fosterOpenScienceFramework2017,
 	title = {Open {Science} {Framework} ({OSF})},
 	volume = {105},
 	copyright = {http://creativecommons.org/licenses/by/4.0},
@@ -1504,7 +1522,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	year = {2017},
 }
 
-@misc{halchenko_overview_2015,
+@misc{halchenkoOverviewStatisticalEvaluation2015,
 	title = {Overview of statistical evaluation techniques adopted by publicly available {MVPA} toolboxes},
 	url = {http://www.pymvpa.org/files/OHBM2015_Halchenko.pdf},
 	author = {Halchenko, Yaroslav. O},
@@ -1512,7 +1530,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	note = {Published: Organization of Human Brain Mapping Annual Meeting, Honolulu HI, USA. Talk},
 }
 
-@article{peroni_packaging_2022,
+@article{soiland-reyesPackagingResearchArtefacts2022,
 	title = {Packaging research artefacts with {RO}-{Crate}},
 	volume = {5},
 	issn = {2451-8484, 2451-8492},
@@ -1536,7 +1554,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {97--138},
 }
 
-@article{kohler_pattern_2013,
+@article{kohlerPatternClassificationPrecedes2013,
 	title = {Pattern classification precedes region-average hemodynamic response in early visual cortex.},
 	volume = {78C},
 	doi = {10.1016/j.neuroimage.2013.04.019},
@@ -1548,7 +1566,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {249--260},
 }
 
-@phdthesis{halchenko_predictive_2009,
+@phdthesis{halchenkoPredictiveDecodingNeural2009,
 	address = {Newark, NJ, USA},
 	type = {{PhD} {Thesis}},
 	title = {Predictive {Decoding} of {Neural} {Data}},
@@ -1560,7 +1578,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	keywords = {Brain Mapping, EEG, Evoked Potentials, Face, Fusion, Machine Learning, fMRI},
 }
 
-@article{gobbini_prioritized_2013,
+@article{gobbiniPrioritizedDetectionPersonally2013,
 	title = {Prioritized {Detection} of {Personally} {Familiar} {Faces}},
 	volume = {8},
 	issn = {1932-6203},
@@ -1573,7 +1591,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	year = {2013},
 }
 
-@article{gobbini_processing_2013,
+@article{gobbiniProcessingInvisibleSocial2013,
 	title = {Processing of invisible social cues},
 	volume = {22},
 	issn = {1053-8100},
@@ -1586,7 +1604,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {765--770},
 }
 
-@article{cheifet_promoting_2021,
+@article{cheifetPromotingReproducibilityCode2021,
 	title = {Promoting reproducibility with {Code} {Ocean}},
 	volume = {22},
 	issn = {1474-760X},
@@ -1602,7 +1620,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {65, s13059--021--02299--x},
 }
 
-@article{baranger_protocol_2021,
+@article{barangerProtocolMachineLearning2021,
 	title = {Protocol for a machine learning algorithm predicting depressive disorders using the {T1w}/{T2w} ratio},
 	volume = {8},
 	url = {https://doi.org/10.1016/j.mex.2021.101595},
@@ -1613,7 +1631,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {101595},
 }
 
-@misc{w3c_provenance_working_group_prov-overview_2013,
+@misc{w3cprovenanceworkinggroupPROVOverviewOverviewPROV2013,
 	title = {{PROV}-{Overview}: {An} {Overview} of the {PROV} {Family} of {Documents}},
 	url = {https://www.w3.org/TR/prov-overview/},
 	urldate = {2026-04-19},
@@ -1623,7 +1641,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	note = {Published: W3C Working Group Note},
 }
 
-@article{yarkoni_pybids_2019,
+@article{yarkoniPyBIDSPythonTools2019,
 	title = {{PyBIDS}: {Python} tools for {BIDS} datasets},
 	volume = {4},
 	url = {https://doi.org/10.21105/joss.01294},
@@ -1635,14 +1653,14 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {1294},
 }
 
-@misc{yarkoni_pybids_2018,
+@misc{yarkoniPybidsPythonTools2018,
 	title = {Pybids: {Python} tools for manipulation and analysis of {BIDS} datasets},
 	author = {Yarkoni, Tal and de la Vega, Alejandro and DuPre, Elizabeth and Esteban, Oscar and Halchenko, Yaroslav O. and Hanke, Michael and Hayot-Sasson, Valerie and Ivanov, Alexander and Kiar, Gregory and Markiewicz, Christopher and McNamara, Quinten and Petrov, Dmitry and Poline, Jean-Baptiste and Poldrack, Russell and Gorgolewski, Krzysztof},
 	year = {2018},
 	note = {Published: Poster presented at the annual meeting of the Organization for Human Brain Mapping, Singapore},
 }
 
-@article{hanke_pymvpa_2009,
+@article{hankePyMVPAPythonToolbox2009,
 	title = {{PyMVPA}: {A} {Python} toolbox for multivariate pattern analysis of {fMRI} data},
 	volume = {7},
 	doi = {10.1007/s12021-008-9041-y},
@@ -1652,7 +1670,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {37--53},
 }
 
-@article{hanke_pymvpa_2009-1,
+@article{hankePyMVPAUnifyingApproach2009,
 	title = {{PyMVPA}: {A} {Unifying} {Approach} to the {Analysis} of {Neuroscientific} {Data}},
 	volume = {3},
 	issn = {1662-5196},
@@ -1663,7 +1681,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {3},
 }
 
-@article{connolly_representation_2012,
+@article{connollyRepresentationBiologicalClasses2012,
 	title = {Representation of biological classes in the human brain},
 	volume = {32},
 	doi = {10.1523/JNEUROSCI.5547-11.2012},
@@ -1675,7 +1693,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {2608--2618},
 }
 
-@misc{courtes_reproducible_2015,
+@misc{courtesReproducibleUserControlledSoftware2015,
 	title = {Reproducible and {User}-{Controlled} {Software} {Environments} in {HPC} with {Guix}},
 	copyright = {arXiv.org perpetual, non-exclusive license},
 	url = {https://arxiv.org/abs/1506.02822},
@@ -1689,7 +1707,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	keywords = {Distributed, Parallel, and Cluster Computing (cs.DC), FOS: Computer and information sciences, Operating Systems (cs.OS), Software Engineering (cs.SE)},
 }
 
-@misc{legrand_reproducible_2022,
+@misc{legrandReproducibleResearchII2022,
 	title = {Reproducible {Research} {II}: {Practices} and {Tools} for {Managing} {Computations} and {Data}},
 	url = {https://www.fun-mooc.fr/en/courses/reproducible-research-ii-practices-and-tools-for-managing-comput/},
 	urldate = {2026-04-19},
@@ -1698,14 +1716,14 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	note = {Published: FUN-MOOC online course},
 }
 
-@misc{visconti_di_oleggio_castello_reproin_2018,
+@misc{viscontidioleggiocastelloReproInAutomaticGeneration2018,
 	title = {{ReproIn}: automatic generation of shareable, version-controlled {BIDS} datasets from {MR} scanners},
 	author = {Visconti di Oleggio Castello, Matteo and Dobson, James and Sackett, Terry and Kodiweera, Chandana and Haxby, James and Goncalves, Mathias and Ghosh, Satrajit and Halchenko, Yaroslav O.},
 	year = {2018},
 	note = {Published: Poster and talk presented at the annual meeting of the Organization for Human Brain Mapping, Singapore},
 }
 
-@misc{halchenko_resources_2016,
+@misc{halchenkoResourcesPracticingPR4NI2016,
 	title = {Resources for practicing {PR4NI} – pragmatic cursory overview},
 	url = {http://www.pymvpa.org/files/OHBM2016_Halchenko_resources.pdf},
 	author = {Halchenko, Yaroslav. O},
@@ -1713,14 +1731,14 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	note = {Published: Organization of Human Brain Mapping Annual Meeting, Tutorials, Geneva, Switzerland. Talk},
 }
 
-@misc{connolly_scanning_2011,
+@misc{connollyScanningParametersOptimal2011,
 	title = {Scanning parameters for optimal decoding using a 32-channel head coil for {fMRI}},
 	author = {Connolly, Andrew C. and Wu, Yu-Chien and Halchenko, Yaroslav O. and Guntupalli, J. Swaroop and Haxby, James V.},
 	year = {2011},
 	note = {Published: Vision Sciences Society Annual Meeting, Naples, FL. Poster},
 }
 
-@misc{johnson_sciops_2024,
+@misc{johnsonSciOpsAchievingProductivity2024,
 	title = {{SciOps}: {Achieving} {Productivity} and {Reliability} in {Data}-{Intensive} {Research}},
 	copyright = {Creative Commons Attribution 4.0 International},
 	shorttitle = {{SciOps}},
@@ -1734,7 +1752,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	keywords = {Computers and Society (cs.CY), FOS: Biological sciences, FOS: Computer and information sciences, Neurons and Cognition (q-bio.NC)},
 }
 
-@article{kopsachilis_semantically-aware_2021,
+@article{kopsachilisSemanticallyAwareRetrievalOceanographic2021,
 	title = {Semantically-{Aware} {Retrieval} of {Oceanographic} {Phenomena} {Annotated} on {Satellite} {Images}},
 	volume = {12},
 	issn = {2078-2489},
@@ -1751,7 +1769,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {321},
 }
 
-@article{ramsey_six_2010,
+@article{ramseySixProblemsCausal2010,
 	title = {Six problems for causal inference from {fMRI}},
 	volume = {49},
 	issn = {1095-9572},
@@ -1765,7 +1783,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	pages = {1545--58},
 }
 
-@article{jung_spacetop_2025,
+@article{jungSpacetopMultimodalFMRI2025,
 	title = {Spacetop: {A} multimodal {fMRI} dataset unifying naturalistic processes with a rich array of experimental tasks},
 	volume = {12},
 	issn = {2052-4463},
@@ -1778,7 +1796,7 @@ This talk will present the design of the Icechunk specification, our Rust-based 
 	year = {2025},
 }
 
-@misc{github_spec_2025,
+@misc{githubSpecKitToolkit2025,
 	title = {Spec {Kit}: {Toolkit} for {Spec}-{Driven} {Development}},
 	url = {https://github.com/github/spec-kit},
 	urldate = {2026-04-19},
@@ -1803,7 +1821,7 @@ First alpha release of the STAMPED checklist schema.},
 	year = {2026},
 }
 
-@misc{yaroslav_halchenko_stamped-principlesstamped-examples_2026,
+@misc{yaroslavhalchenkoStampedprinciplesStampedexamplesPreprint2026,
 	title = {stamped-principles/stamped-examples: {Pre}-print ready},
 	copyright = {Creative Commons Attribution 4.0 International},
 	shorttitle = {stamped-principles/stamped-examples},
@@ -1835,6 +1853,7 @@ Full Changelog: https://github.com/stamped-principles/stamped-examples/commits/0
 	copyright = {Creative Commons Attribution 4.0 International},
 	shorttitle = {stamped-principles/stamped-principles-schema},
 	url = {https://zenodo.org/doi/10.5281/zenodo.19672387},
+	doi = {10.5281/ZENODO.19672387},
 	abstract = {v0.1.0
 
 First alpha release of the STAMPED principles schema.},
@@ -1843,10 +1862,9 @@ First alpha release of the STAMPED principles schema.},
 	author = {{Cody Baker}},
 	month = apr,
 	year = {2026},
-	doi = {10.5281/ZENODO.19672387},
 }
 
-@article{gentleman_statistical_2007,
+@article{gentlemanStatisticalAnalysesReproducible2007,
 	title = {Statistical {Analyses} and {Reproducible} {Research}},
 	volume = {16},
 	issn = {1061-8600, 1537-2715},
@@ -1862,7 +1880,7 @@ First alpha release of the STAMPED principles schema.},
 	pages = {1--23},
 }
 
-@article{hanke_statistical_2010,
+@article{hankeStatisticalLearningAnalysis2010,
 	title = {Statistical learning analysis in neuroscience: aiming for transparency},
 	volume = {4},
 	doi = {10.3389/neuro.01.007.2010},
@@ -1872,7 +1890,7 @@ First alpha release of the STAMPED principles schema.},
 	pages = {38--43},
 }
 
-@inproceedings{hanson_structural_2004,
+@inproceedings{hansonStructuralEquationModeling2004,
 	title = {Structural {Equation} {Modeling} of {Neuroimaging} {Data}: {Exhaustive} {Search} and {Markov} {Chain} {Monte} {Carlo}},
 	booktitle = {Human {Brain} {Mapping}},
 	author = {Hanson, S. J. and Matsuka, T. and Hanson, C. and Rebbechi, D. and Halchenko, Y. O. and Zaimi, A. and Pearlmutter, B. A.},
@@ -1880,7 +1898,7 @@ First alpha release of the STAMPED principles schema.},
 	keywords = {MCMC, Modeling},
 }
 
-@article{molder_sustainable_2021,
+@article{molderSustainableDataAnalysis2021,
 	title = {Sustainable data analysis with {Snakemake}},
 	volume = {10},
 	issn = {2046-1402},
@@ -1897,7 +1915,7 @@ First alpha release of the STAMPED principles schema.},
 	pages = {33},
 }
 
-@article{kowalewski_sustainable_2022,
+@article{kowalewskiSustainablePackagingQuantum2022,
 	title = {Sustainable packaging of quantum chemistry software with the {Nix} package manager},
 	volume = {122},
 	issn = {0020-7608, 1097-461X},
@@ -1915,7 +1933,7 @@ First alpha release of the STAMPED principles schema.},
 	pages = {e26872},
 }
 
-@article{ciric_templateflow_2021,
+@article{ciricTemplateFlowCommunityArchive2021,
 	title = {{TemplateFlow}: a community archive of imaging templates and atlases for improved consistency in neuroimaging},
 	url = {https://doi.org/10.1101/2021.02.10.430678},
 	doi = {10.1101/2021.02.10.430678},
@@ -1924,7 +1942,7 @@ First alpha release of the STAMPED principles schema.},
 	year = {2021},
 }
 
-@article{ciric_templateflow_2022,
+@article{ciricTemplateFlowFAIRsharingMultiscale2022,
 	title = {{TemplateFlow}: {FAIR}-sharing of multi-scale, multi-species brain models},
 	volume = {19},
 	issn = {1548-7091, 1548-7105},
@@ -1943,14 +1961,14 @@ First alpha release of the STAMPED principles schema.},
 	pages = {1568--1571},
 }
 
-@misc{contier_temporal_2018,
+@misc{contierTemporalDynamicsEffective2018,
 	title = {Temporal dynamics and effective connectivity in the distributed system of familiar face processing},
 	author = {Contier, Oliver and Visconti di Oleggio Castello, Matteo and Gobbini, M. Ida and Halchenko, Yaroslav O.},
 	year = {2018},
 	note = {Published: Poster presented at the annual meeting of the Organization for Human Brain Mapping, Singapore},
 }
 
-@article{sandve_ten_2013,
+@article{sandveTenSimpleRules2013,
 	title = {Ten {Simple} {Rules} for {Reproducible} {Computational} {Research}},
 	volume = {9},
 	issn = {1553-7358},
@@ -1967,7 +1985,7 @@ First alpha release of the STAMPED principles schema.},
 	pages = {e1003285},
 }
 
-@article{nastase_narratives_2021,
+@article{nastaseNarrativesFMRIDataset2021,
 	title = {The “{Narratives}” {fMRI} dataset for evaluating models of naturalistic language comprehension},
 	volume = {8},
 	issn = {2052-4463},
@@ -1985,7 +2003,7 @@ First alpha release of the STAMPED principles schema.},
 	pages = {250},
 }
 
-@misc{lu_ai_2024,
+@misc{luAIScientistFully2024,
 	title = {The {AI} {Scientist}: {Towards} {Fully} {Automated} {Open}-{Ended} {Scientific} {Discovery}},
 	shorttitle = {The {AI} {Scientist}},
 	url = {http://arxiv.org/abs/2408.06292},
@@ -2000,35 +2018,48 @@ First alpha release of the STAMPED principles schema.},
 	keywords = {Computer Science - Artificial Intelligence, Computer Science - Computation and Language, Computer Science - Machine Learning},
 }
 
-@article{sha_animacy_2015,
+@article{shaAnimacyContinuumHuman2015,
 	title = {The animacy continuum in the human ventral vision pathway},
 	volume = {27:4},
 	doi = {10.1162/jocn_a_00733},
 	journal = {Journal of Cognitive Neuroscience},
 	author = {Sha, Long and Haxby, James V. and Abdi, Hervé and Guntupalli, J. Swaroop and Oosterhof, Nikolaas N. and Halchenko, Yaroslav O. and Connolly, Andrew C.},
 	year = {2015},
-	pmid = {25269114},
 	pages = {665--678},
 }
 
-@misc{maumet_best_2019,
+@misc{maumetBestBothWorlds2019,
 	title = {The best of both worlds: using semantic web with {JSON}-{LD}. {An} example with {NIDM}-{Results} \& {DataLad}},
 	author = {Maumet, Camille and Ghosh, Satrajit and Halchenko, Yaroslav O. and Dorota, Jarecka and Nichols, Nolan and Poline, Jean-Baptiste and Hanke, Michael},
 	year = {2019},
 	note = {Published: Poster presented at the annual meeting of the Organization for Human Brain Mapping, Rome, Italy},
 }
 
-@misc{gorgolewski_brain_2020,
+@misc{gorgolewskiBrainImagingData2020,
 	title = {The {Brain} {Imaging} {Data} {Structure} ({BIDS}) {Specification}, {Version} 1.3.0},
 	url = {https://doi.org/10.5281/zenodo.3720628},
+	doi = {10.5281/zenodo.3720628},
 	publisher = {Zenodo},
 	author = {Gorgolewski, Kzrysztof J and Poline, Jean-Baptiste and Keator, David B and Nichols, B Nolan and Auer, Tibor and Craddock, R Cameron and Flandin, Guillaume and Ghosh, Satrajit S and Sochat, Vanessa V and Rokem, Ariel and Halchenko, Yaroslav O and Hanke, Michael and Haselgrove, Christian and Helmer, Karl and Maumet, Camille and Nichols, Thomas E and Turner, Jessica A and Das, Samir and Kennedy, David N and Poldrack, Russell A},
 	month = apr,
 	year = {2020},
-	doi = {10.5281/zenodo.3720628},
 }
 
-@article{gorgolewski_brain_2016,
+@article{gorgolewskiBrainImagingData2016a,
+	title = {The brain imaging data structure, a format for organizing and describing outputs of neuroimaging experiments},
+	volume = {3},
+	issn = {2052-4463},
+	url = {http://www.nature.com/articles/sdata201644},
+	doi = {10.1038/sdata.2016.44},
+	urldate = {2016-06-21},
+	journal = {Scientific Data},
+	author = {Gorgolewski, Krzysztof J. and Auer, Tibor and Calhoun, Vince D. and Craddock, R. Cameron and Das, Samir and Duff, Eugene P. and Flandin, Guillaume and Ghosh, Satrajit S. and Glatard, Tristan and Halchenko, Yaroslav O. and Handwerker, Daniel A. and Hanke, Michael and Keator, David and Li, Xiangrui and Michael, Zachary and Maumet, Camille and Nichols, B. Nolan and Nichols, Thomas E. and Pellman, John and Poline, Jean-Baptiste and Rokem, Ariel and Schaefer, Gunnar and Sochat, Vanessa and Triplett, William and Turner, Jessica A. and Varoquaux, Gaël and Poldrack, Russell A.},
+	month = jun,
+	year = {2016},
+	pages = {160044},
+}
+
+@article{gorgolewskiBrainImagingData2016b,
 	title = {The brain imaging data structure, a format for organizing and describing outputs of neuroimaging experiments},
 	volume = {3},
 	issn = {2052-4463},
@@ -2047,21 +2078,7 @@ First alpha release of the STAMPED principles schema.},
 	pages = {160044},
 }
 
-@article{gorgolewski_brain_2016-1,
-	title = {The brain imaging data structure, a format for organizing and describing outputs of neuroimaging experiments},
-	volume = {3},
-	issn = {2052-4463},
-	url = {http://www.nature.com/articles/sdata201644},
-	doi = {10.1038/sdata.2016.44},
-	urldate = {2016-06-21},
-	journal = {Scientific Data},
-	author = {Gorgolewski, Krzysztof J. and Auer, Tibor and Calhoun, Vince D. and Craddock, R. Cameron and Das, Samir and Duff, Eugene P. and Flandin, Guillaume and Ghosh, Satrajit S. and Glatard, Tristan and Halchenko, Yaroslav O. and Handwerker, Daniel A. and Hanke, Michael and Keator, David and Li, Xiangrui and Michael, Zachary and Maumet, Camille and Nichols, B. Nolan and Nichols, Thomas E. and Pellman, John and Poline, Jean-Baptiste and Rokem, Ariel and Schaefer, Gunnar and Sochat, Vanessa and Triplett, William and Turner, Jessica A. and Varoquaux, Gaël and Poldrack, Russell A.},
-	month = jun,
-	year = {2016},
-	pages = {160044},
-}
-
-@article{gorgolewski_brain_2016-2,
+@article{gorgolewskiBrainImagingData2016,
 	title = {The {Brain} {Imaging} {Data} {Structure}: a standard for organizing and describing outputs of neuroimaging experiments},
 	url = {http://biorxiv.org/content/early/2016/02/05/034561},
 	doi = {10.1101/034561},
@@ -2070,7 +2087,7 @@ First alpha release of the STAMPED principles schema.},
 	year = {2016},
 }
 
-@article{wilkinson_fair_2016,
+@article{wilkinsonFAIRGuidingPrinciples2016,
 	title = {The {FAIR} {Guiding} {Principles} for scientific data management and stewardship},
 	volume = {3},
 	issn = {2052-4463},
@@ -2088,7 +2105,7 @@ First alpha release of the STAMPED principles schema.},
 	pages = {160018},
 }
 
-@article{afgan_galaxy_2018,
+@article{afganGalaxyPlatformAccessible2018,
 	title = {The {Galaxy} platform for accessible, reproducible and collaborative biomedical analyses: 2018 update},
 	volume = {46},
 	copyright = {http://creativecommons.org/licenses/by/4.0/},
@@ -2106,7 +2123,7 @@ First alpha release of the STAMPED principles schema.},
 	pages = {W537--W544},
 }
 
-@misc{gorgolewski_impact_2015,
+@misc{gorgolewskiImpactSharedData2015,
 	title = {The impact of shared data in neuroimaging: the case of {OpenfMRI}.org},
 	url = {http://f1000research.com/posters/4-299},
 	author = {Gorgolewski, Krzysztof and Wheeler, Kelsey and Halchenko, Yaroslav O. and Poline, Jean Baptiste and Poldrack, Russell},
@@ -2114,17 +2131,7 @@ First alpha release of the STAMPED principles schema.},
 	note = {Published: Organization of Human Brain Mapping Annual Meeting, Honolulu HI, USA. Poster},
 }
 
-@article{feilong_individualized_2023,
-	title = {The {Individualized} {Neural} {Tuning} {Model}: {Precise} and generalizable cartography of functional architecture in individual brains},
-	issn = {2837-6056},
-	url = {http://dx.doi.org/10.1162/imag\_a\_00032},
-	doi = {10.1162/imag_a_00032},
-	journal = {Imaging Neuroscience},
-	author = {Feilong, Ma and Nastase, Samuel A. and Jiahui, Guo and Halchenko, Yaroslav O. and Gobbini, M. Ida and Haxby, James V.},
-	year = {2023},
-}
-
-@article{feilong_individualized_2022,
+@article{feilongIndividualizedNeuralTuning2022,
 	title = {The {Individualized} {Neural} {Tuning} {Model}: {Precise} and generalizable cartography of functional architecture in individual brains},
 	url = {https://doi.org/10.1101/2022.05.15.492022},
 	doi = {10.1101/2022.05.15.492022},
@@ -2134,7 +2141,17 @@ First alpha release of the STAMPED principles schema.},
 	year = {2022},
 }
 
-@article{manelis_interaction_2022,
+@article{feilongIndividualizedNeuralTuning2023,
+	title = {The {Individualized} {Neural} {Tuning} {Model}: {Precise} and generalizable cartography of functional architecture in individual brains},
+	issn = {2837-6056},
+	url = {http://dx.doi.org/10.1162/imag\_a\_00032},
+	doi = {10.1162/imag_a_00032},
+	journal = {Imaging Neuroscience},
+	author = {Feilong, Ma and Nastase, Samuel A. and Jiahui, Guo and Halchenko, Yaroslav O. and Gobbini, M. Ida and Haxby, James V.},
+	year = {2023},
+}
+
+@article{manelisInteractionDepressionDiagnosis2022,
 	title = {The interaction between depression diagnosis and {BMI} is related to altered activation pattern in the right inferior frontal gyrus and anterior cingulate cortex during food anticipation},
 	volume = {12},
 	url = {https://doi.org/10.1002/brb3.2695},
@@ -2146,7 +2163,7 @@ First alpha release of the STAMPED principles schema.},
 	year = {2022},
 }
 
-@article{manelis_interaction_2021,
+@article{manelisInteractionLifetimeDepression2021,
 	title = {The interaction between lifetime depression severity and {BMI} is related to altered activation pattern in the right inferior frontal gyrus during food anticipation},
 	url = {https://doi.org/10.1101/2021.02.17.21251922},
 	doi = {10.1101/2021.02.17.21251922},
@@ -2155,7 +2172,7 @@ First alpha release of the STAMPED principles schema.},
 	year = {2021},
 }
 
-@incollection{martinyuk_model_1997,
+@incollection{martinyukModelAssociativeProcessor1997,
 	address = {Vinnytsya, Ukraine},
 	title = {The model of associative processor for numerical data sorting},
 	volume = {2},
@@ -2166,7 +2183,16 @@ First alpha release of the STAMPED principles schema.},
 	pages = {19--23},
 }
 
-@article{visconti_di_oleggio_castello_neural_2017,
+@article{viscontidioleggiocastelloNeuralRepresentationPersonally2017,
+	title = {The {Neural} {Representation} {Of} {Personally} {Familiar} {And} {Unfamiliar} {Faces} {In} {The} {Distributed} {System} {For} {Face} {Perception}},
+	url = {http://biorxiv.org/content/early/2017/05/15/138297},
+	doi = {10.1101/138297},
+	journal = {bioRxiv},
+	author = {Visconti di Oleggio Castello, Matteo and Halchenko, Yaroslav O. and Guntupalli, J. Swaroop and Gors, Jason D. and Gobbini, Maria Ida},
+	year = {2017},
+}
+
+@article{viscontidioleggiocastelloNeuralRepresentationPersonally2017a,
 	title = {The {Neural} {Representation} {Of} {Personally} {Familiar} {And} {Unfamiliar} {Faces} {In} {The} {Distributed} {System} {For} {Face} {Perception}},
 	volume = {7},
 	doi = {10.1038/s41598-017-12559-1},
@@ -2176,16 +2202,29 @@ First alpha release of the STAMPED principles schema.},
 	year = {2017},
 }
 
-@article{visconti_di_oleggio_castello_neural_2017-1,
-	title = {The {Neural} {Representation} {Of} {Personally} {Familiar} {And} {Unfamiliar} {Faces} {In} {The} {Distributed} {System} {For} {Face} {Perception}},
-	url = {http://biorxiv.org/content/early/2017/05/15/138297},
-	doi = {10.1101/138297},
-	journal = {bioRxiv},
-	author = {Visconti di Oleggio Castello, Matteo and Halchenko, Yaroslav O. and Guntupalli, J. Swaroop and Gors, Jason D. and Gobbini, Maria Ida},
-	year = {2017},
+@article{rubelNeurodataBordersEcosystem2022,
+	title = {The {Neurodata} {Without} {Borders} ecosystem for neurophysiological data science},
+	volume = {11},
+	copyright = {CC BY 4.0},
+	url = {https://elifesciences.org/articles/78362},
+	doi = {10.7554/eLife.78362},
+	language = {en},
+	journal = {eLife},
+	author = {Rübel, Oliver and Tritt, Andrew and Ly, Ryan and Dichter, Benjamin K and Ghosh, Satrajit and Niu, Lawrence and Baker, Pamela and Soltesz, Ivan and Ng, Lydia and Svoboda, Karel and Frank, Loren and Bouchard, Kristofer E},
+	month = oct,
+	year = {2022},
+	pages = {e78362},
 }
 
-@article{bannier_open_2021,
+@article{pernetOpenBrainConsent2020,
+	title = {The {Open} {Brain} {Consent}: {Informing} research participants and obtaining consent to share brain imaging data},
+	doi = {10.31234/osf.io/f6mnp},
+	author = {Pernet, Cyril R. and Heunis, Stephan and Herholz, Peer and Halchenko, Yaroslav O.},
+	month = jul,
+	year = {2020},
+}
+
+@article{bannierOpenBrainConsent2021,
 	title = {The {Open} {Brain} {Consent}: {Informing} research participants and obtaining consent to share brain imaging data},
 	url = {https://doi.org/10.1002/hbm.25351},
 	doi = {10.1002/hbm.25351},
@@ -2195,15 +2234,7 @@ First alpha release of the STAMPED principles schema.},
 	year = {2021},
 }
 
-@article{pernet_open_2020,
-	title = {The {Open} {Brain} {Consent}: {Informing} research participants and obtaining consent to share brain imaging data},
-	doi = {10.31234/osf.io/f6mnp},
-	author = {Pernet, Cyril R. and Heunis, Stephan and Herholz, Peer and Halchenko, Yaroslav O.},
-	month = jul,
-	year = {2020},
-}
-
-@article{markiewicz_openneuro_2021,
+@article{markiewiczOpenNeuroResourceSharing2021,
 	title = {The {OpenNeuro} resource for sharing of neuroscience data},
 	volume = {10},
 	issn = {2050-084X},
@@ -2221,35 +2252,7 @@ First alpha release of the STAMPED principles schema.},
 	pages = {e71774},
 }
 
-@article{poldrack_past_2023,
-	title = {The {Past}, {Present}, and {Future} of the {Brain} {Imaging} {Data} {Structure} ({BIDS})},
-	copyright = {Creative Commons Attribution 4.0 International},
-	url = {https://arxiv.org/abs/2309.05768},
-	doi = {10.48550/ARXIV.2309.05768},
-	abstract = {The Brain Imaging Data Structure (BIDS) is a community-driven standard for the organization of data and metadata from a growing range of neuroscience modalities. This paper is meant as a history of how the standard has developed and grown over time. We outline the principles behind the project, the mechanisms by which it has been extended, and some of the challenges being addressed as it evolves. We also discuss the lessons learned through the project, with the aim of enabling researchers in other domains to learn from the success of BIDS.},
-	urldate = {2023-12-19},
-	publisher = {arXiv},
-	author = {Poldrack, Russell A. and Markiewicz, Christopher J. and Appelhoff, Stefan and Ashar, Yoni K. and Auer, Tibor and Baillet, Sylvain and Bansal, Shashank and Beltrachini, Leandro and Benar, Christian G. and Bertazzoli, Giacomo and Bhogawar, Suyash and Blair, Ross W. and Bortoletto, Marta and Boudreau, Mathieu and Brooks, Teon L. and Calhoun, Vince D. and Castelli, Filippo Maria and Clement, Patricia and Cohen, Alexander L and Cohen-Adad, Julien and D'Ambrosio, Sasha and de Hollander, Gilles and de la iglesia-Vayá, María and de la Vega, Alejandro and Delorme, Arnaud and Devinsky, Orrin and Draschkow, Dejan and Duff, Eugene Paul and DuPre, Elizabeth and Earl, Eric and Esteban, Oscar and Feingold, Franklin W. and Flandin, Guillaume and galassi, anthony and Gallitto, Giuseppe and Ganz, Melanie and Gau, Rémi and Gholam, James and Ghosh, Satrajit S. and Giacomel, Alessio and Gillman, Ashley G and Gleeson, Padraig and Gramfort, Alexandre and Guay, Samuel and Guidali, Giacomo and Halchenko, Yaroslav O. and Handwerker, Daniel A. and Hardcastle, Nell and Herholz, Peer and Hermes, Dora and Honey, Christopher J. and Innis, Robert B. and Ioanas, Horea-Ioan and Jahn, Andrew and Karakuzu, Agah and Keator, David B. and Kiar, Gregory and Kincses, Balint and Laird, Angela R. and Lau, Jonathan C. and Lazari, Alberto and Legarreta, Jon Haitz and Li, Adam and Li, Xiangrui and Love, Bradley C. and Lu, Hanzhang and Maumet, Camille and Mazzamuto, Giacomo and Meisler, Steven L. and Mikkelsen, Mark and Mutsaerts, Henk and Nichols, Thomas E. and Nikolaidis, Aki and Nilsonne, Gustav and Niso, Guiomar and Norgaard, Martin and Okell, Thomas W and Oostenveld, Robert and Ort, Eduard and Park, Patrick J. and Pawlik, Mateusz and Pernet, Cyril R. and Pestilli, Franco and Petr, Jan and Phillips, Christophe and Poline, Jean-Baptiste and Pollonini, Luca and Raamana, Pradeep Reddy and Ritter, Petra and Rizzo, Gaia and Robbins, Kay A. and Rockhill, Alexander P. and Rogers, Christine and Rokem, Ariel and Rorden, Chris and Routier, Alexandre and Saborit-Torres, Jose Manuel and Salo, Taylor and Schirner, Michael and Smith, Robert E. and Spisak, Tamas and Sprenger, Julia and Swann, Nicole C. and Szinte, Martin and Takerkart, Sylvain and Thirion, Bertrand and Thomas, Adam G. and Torabian, Sajjad and Varoquaux, Gael and Voytek, Bradley and Welzel, Julius and Wilson, Martin and Yarkoni, Tal and Gorgolewski, Krzysztof J.},
-	year = {2023},
-	note = {Version Number: 1},
-	keywords = {BIDS, Base},
-}
-
-@article{poldrack_past_2023-1,
-	title = {The {Past}, {Present}, and {Future} of the {Brain} {Imaging} {Data} {Structure} ({BIDS})},
-	copyright = {Creative Commons Attribution 4.0 International},
-	url = {https://arxiv.org/abs/2309.05768},
-	doi = {10.48550/ARXIV.2309.05768},
-	abstract = {The Brain Imaging Data Structure (BIDS) is a community-driven standard for the organization of data and metadata from a growing range of neuroscience modalities. This paper is meant as a history of how the standard has developed and grown over time. We outline the principles behind the project, the mechanisms by which it has been extended, and some of the challenges being addressed as it evolves. We also discuss the lessons learned through the project, with the aim of enabling researchers in other domains to learn from the success of BIDS.},
-	urldate = {2023-12-19},
-	publisher = {arXiv},
-	author = {Poldrack, Russell A. and Markiewicz, Christopher J. and Appelhoff, Stefan and Ashar, Yoni K. and Auer, Tibor and Baillet, Sylvain and Bansal, Shashank and Beltrachini, Leandro and Benar, Christian G. and Bertazzoli, Giacomo and Bhogawar, Suyash and Blair, Ross W. and Bortoletto, Marta and Boudreau, Mathieu and Brooks, Teon L. and Calhoun, Vince D. and Castelli, Filippo Maria and Clement, Patricia and Cohen, Alexander L and Cohen-Adad, Julien and D'Ambrosio, Sasha and de Hollander, Gilles and de la iglesia-Vayá, María and de la Vega, Alejandro and Delorme, Arnaud and Devinsky, Orrin and Draschkow, Dejan and Duff, Eugene Paul and DuPre, Elizabeth and Earl, Eric and Esteban, Oscar and Feingold, Franklin W. and Flandin, Guillaume and galassi, anthony and Gallitto, Giuseppe and Ganz, Melanie and Gau, Rémi and Gholam, James and Ghosh, Satrajit S. and Giacomel, Alessio and Gillman, Ashley G and Gleeson, Padraig and Gramfort, Alexandre and Guay, Samuel and Guidali, Giacomo and Halchenko, Yaroslav O. and Handwerker, Daniel A. and Hardcastle, Nell and Herholz, Peer and Hermes, Dora and Honey, Christopher J. and Innis, Robert B. and Ioanas, Horea-Ioan and Jahn, Andrew and Karakuzu, Agah and Keator, David B. and Kiar, Gregory and Kincses, Balint and Laird, Angela R. and Lau, Jonathan C. and Lazari, Alberto and Legarreta, Jon Haitz and Li, Adam and Li, Xiangrui and Love, Bradley C. and Lu, Hanzhang and Maumet, Camille and Mazzamuto, Giacomo and Meisler, Steven L. and Mikkelsen, Mark and Mutsaerts, Henk and Nichols, Thomas E. and Nikolaidis, Aki and Nilsonne, Gustav and Niso, Guiomar and Norgaard, Martin and Okell, Thomas W and Oostenveld, Robert and Ort, Eduard and Park, Patrick J. and Pawlik, Mateusz and Pernet, Cyril R. and Pestilli, Franco and Petr, Jan and Phillips, Christophe and Poline, Jean-Baptiste and Pollonini, Luca and Raamana, Pradeep Reddy and Ritter, Petra and Rizzo, Gaia and Robbins, Kay A. and Rockhill, Alexander P. and Rogers, Christine and Rokem, Ariel and Rorden, Chris and Routier, Alexandre and Saborit-Torres, Jose Manuel and Salo, Taylor and Schirner, Michael and Smith, Robert E. and Spisak, Tamas and Sprenger, Julia and Swann, Nicole C. and Szinte, Martin and Takerkart, Sylvain and Thirion, Bertrand and Thomas, Adam G. and Torabian, Sajjad and Varoquaux, Gael and Voytek, Bradley and Welzel, Julius and Wilson, Martin and Yarkoni, Tal and Gorgolewski, Krzysztof J.},
-	year = {2023},
-	note = {Version Number: 1},
-	keywords = {BIDS, Base},
-}
-
-@article{poldrack_past_2024,
+@article{poldrackPresentFutureBrain2024,
 	title = {The past, present, and future of the brain imaging data structure ({BIDS})},
 	volume = {2},
 	issn = {2837-6056},
@@ -2262,7 +2265,35 @@ First alpha release of the STAMPED principles schema.},
 	pages = {1--19},
 }
 
-@article{nosek_preregistration_2018,
+@article{poldrackPresentFutureBrain2023,
+	title = {The {Past}, {Present}, and {Future} of the {Brain} {Imaging} {Data} {Structure} ({BIDS})},
+	copyright = {Creative Commons Attribution 4.0 International},
+	url = {https://arxiv.org/abs/2309.05768},
+	doi = {10.48550/ARXIV.2309.05768},
+	abstract = {The Brain Imaging Data Structure (BIDS) is a community-driven standard for the organization of data and metadata from a growing range of neuroscience modalities. This paper is meant as a history of how the standard has developed and grown over time. We outline the principles behind the project, the mechanisms by which it has been extended, and some of the challenges being addressed as it evolves. We also discuss the lessons learned through the project, with the aim of enabling researchers in other domains to learn from the success of BIDS.},
+	urldate = {2023-12-19},
+	publisher = {arXiv},
+	author = {Poldrack, Russell A. and Markiewicz, Christopher J. and Appelhoff, Stefan and Ashar, Yoni K. and Auer, Tibor and Baillet, Sylvain and Bansal, Shashank and Beltrachini, Leandro and Benar, Christian G. and Bertazzoli, Giacomo and Bhogawar, Suyash and Blair, Ross W. and Bortoletto, Marta and Boudreau, Mathieu and Brooks, Teon L. and Calhoun, Vince D. and Castelli, Filippo Maria and Clement, Patricia and Cohen, Alexander L and Cohen-Adad, Julien and D'Ambrosio, Sasha and de Hollander, Gilles and de la iglesia-Vayá, María and de la Vega, Alejandro and Delorme, Arnaud and Devinsky, Orrin and Draschkow, Dejan and Duff, Eugene Paul and DuPre, Elizabeth and Earl, Eric and Esteban, Oscar and Feingold, Franklin W. and Flandin, Guillaume and galassi, anthony and Gallitto, Giuseppe and Ganz, Melanie and Gau, Rémi and Gholam, James and Ghosh, Satrajit S. and Giacomel, Alessio and Gillman, Ashley G and Gleeson, Padraig and Gramfort, Alexandre and Guay, Samuel and Guidali, Giacomo and Halchenko, Yaroslav O. and Handwerker, Daniel A. and Hardcastle, Nell and Herholz, Peer and Hermes, Dora and Honey, Christopher J. and Innis, Robert B. and Ioanas, Horea-Ioan and Jahn, Andrew and Karakuzu, Agah and Keator, David B. and Kiar, Gregory and Kincses, Balint and Laird, Angela R. and Lau, Jonathan C. and Lazari, Alberto and Legarreta, Jon Haitz and Li, Adam and Li, Xiangrui and Love, Bradley C. and Lu, Hanzhang and Maumet, Camille and Mazzamuto, Giacomo and Meisler, Steven L. and Mikkelsen, Mark and Mutsaerts, Henk and Nichols, Thomas E. and Nikolaidis, Aki and Nilsonne, Gustav and Niso, Guiomar and Norgaard, Martin and Okell, Thomas W and Oostenveld, Robert and Ort, Eduard and Park, Patrick J. and Pawlik, Mateusz and Pernet, Cyril R. and Pestilli, Franco and Petr, Jan and Phillips, Christophe and Poline, Jean-Baptiste and Pollonini, Luca and Raamana, Pradeep Reddy and Ritter, Petra and Rizzo, Gaia and Robbins, Kay A. and Rockhill, Alexander P. and Rogers, Christine and Rokem, Ariel and Rorden, Chris and Routier, Alexandre and Saborit-Torres, Jose Manuel and Salo, Taylor and Schirner, Michael and Smith, Robert E. and Spisak, Tamas and Sprenger, Julia and Swann, Nicole C. and Szinte, Martin and Takerkart, Sylvain and Thirion, Bertrand and Thomas, Adam G. and Torabian, Sajjad and Varoquaux, Gael and Voytek, Bradley and Welzel, Julius and Wilson, Martin and Yarkoni, Tal and Gorgolewski, Krzysztof J.},
+	year = {2023},
+	note = {Version Number: 1},
+	keywords = {BIDS, Base},
+}
+
+@article{poldrackPresentFutureBrain2023a,
+	title = {The {Past}, {Present}, and {Future} of the {Brain} {Imaging} {Data} {Structure} ({BIDS})},
+	copyright = {Creative Commons Attribution 4.0 International},
+	url = {https://arxiv.org/abs/2309.05768},
+	doi = {10.48550/ARXIV.2309.05768},
+	abstract = {The Brain Imaging Data Structure (BIDS) is a community-driven standard for the organization of data and metadata from a growing range of neuroscience modalities. This paper is meant as a history of how the standard has developed and grown over time. We outline the principles behind the project, the mechanisms by which it has been extended, and some of the challenges being addressed as it evolves. We also discuss the lessons learned through the project, with the aim of enabling researchers in other domains to learn from the success of BIDS.},
+	urldate = {2023-12-19},
+	publisher = {arXiv},
+	author = {Poldrack, Russell A. and Markiewicz, Christopher J. and Appelhoff, Stefan and Ashar, Yoni K. and Auer, Tibor and Baillet, Sylvain and Bansal, Shashank and Beltrachini, Leandro and Benar, Christian G. and Bertazzoli, Giacomo and Bhogawar, Suyash and Blair, Ross W. and Bortoletto, Marta and Boudreau, Mathieu and Brooks, Teon L. and Calhoun, Vince D. and Castelli, Filippo Maria and Clement, Patricia and Cohen, Alexander L and Cohen-Adad, Julien and D'Ambrosio, Sasha and de Hollander, Gilles and de la iglesia-Vayá, María and de la Vega, Alejandro and Delorme, Arnaud and Devinsky, Orrin and Draschkow, Dejan and Duff, Eugene Paul and DuPre, Elizabeth and Earl, Eric and Esteban, Oscar and Feingold, Franklin W. and Flandin, Guillaume and galassi, anthony and Gallitto, Giuseppe and Ganz, Melanie and Gau, Rémi and Gholam, James and Ghosh, Satrajit S. and Giacomel, Alessio and Gillman, Ashley G and Gleeson, Padraig and Gramfort, Alexandre and Guay, Samuel and Guidali, Giacomo and Halchenko, Yaroslav O. and Handwerker, Daniel A. and Hardcastle, Nell and Herholz, Peer and Hermes, Dora and Honey, Christopher J. and Innis, Robert B. and Ioanas, Horea-Ioan and Jahn, Andrew and Karakuzu, Agah and Keator, David B. and Kiar, Gregory and Kincses, Balint and Laird, Angela R. and Lau, Jonathan C. and Lazari, Alberto and Legarreta, Jon Haitz and Li, Adam and Li, Xiangrui and Love, Bradley C. and Lu, Hanzhang and Maumet, Camille and Mazzamuto, Giacomo and Meisler, Steven L. and Mikkelsen, Mark and Mutsaerts, Henk and Nichols, Thomas E. and Nikolaidis, Aki and Nilsonne, Gustav and Niso, Guiomar and Norgaard, Martin and Okell, Thomas W and Oostenveld, Robert and Ort, Eduard and Park, Patrick J. and Pawlik, Mateusz and Pernet, Cyril R. and Pestilli, Franco and Petr, Jan and Phillips, Christophe and Poline, Jean-Baptiste and Pollonini, Luca and Raamana, Pradeep Reddy and Ritter, Petra and Rizzo, Gaia and Robbins, Kay A. and Rockhill, Alexander P. and Rogers, Christine and Rokem, Ariel and Rorden, Chris and Routier, Alexandre and Saborit-Torres, Jose Manuel and Salo, Taylor and Schirner, Michael and Smith, Robert E. and Spisak, Tamas and Sprenger, Julia and Swann, Nicole C. and Szinte, Martin and Takerkart, Sylvain and Thirion, Bertrand and Thomas, Adam G. and Torabian, Sajjad and Varoquaux, Gael and Voytek, Bradley and Welzel, Julius and Wilson, Martin and Yarkoni, Tal and Gorgolewski, Krzysztof J.},
+	year = {2023},
+	note = {Version Number: 1},
+	keywords = {BIDS, Base},
+}
+
+@article{nosekPreregistrationRevolution2018,
 	title = {The preregistration revolution},
 	volume = {115},
 	issn = {0027-8424, 1091-6490},
@@ -2279,7 +2310,7 @@ First alpha release of the STAMPED principles schema.},
 	pages = {2600--2606},
 }
 
-@article{torabian_pymvpa_2023,
+@article{torabianPyMVPABIDSAppRobust2023,
 	title = {The {PyMVPA} {BIDS}-{App}: a robust multivariate pattern analysis pipeline for {fMRI} data},
 	volume = {17},
 	issn = {1662-453X},
@@ -2297,7 +2328,7 @@ First alpha release of the STAMPED principles schema.},
 	keywords = {BIDS-App, Bids, MVPA, Machine Learning, PyMVPA, Software, fMRI},
 }
 
-@article{satz_relationship_2022,
+@article{satzRelationshipDefaultMode2022,
 	title = {The {Relationship} {Between} {Default} {Mode} and {Dorsal} {Attention} {Networks} {Is} {Associated} {With} {Depressive} {Disorder} {Diagnosis} and the {Strength} of {Memory} {Representations} {Acquired} {Prior} to the {Resting} {State} {Scan}},
 	volume = {16},
 	url = {https://doi.org/10.3389/fnhum.2022.749767},
@@ -2308,7 +2339,7 @@ First alpha release of the STAMPED principles schema.},
 	year = {2022},
 }
 
-@article{leipzig_role_2021,
+@article{leipzigRoleMetadataReproducible2021,
 	title = {The role of metadata in reproducible computational research},
 	volume = {2},
 	issn = {26663899},
@@ -2324,7 +2355,7 @@ First alpha release of the STAMPED principles schema.},
 	pages = {100322},
 }
 
-@article{stodden_scientific_2010,
+@article{stoddenScientificMethodPractice2010,
 	title = {The {Scientific} {Method} in {Practice}: {Reproducibility} in the {Computational} {Sciences}},
 	issn = {1556-5068},
 	shorttitle = {The {Scientific} {Method} in {Practice}},
@@ -2337,7 +2368,7 @@ First alpha release of the STAMPED principles schema.},
 	year = {2010},
 }
 
-@article{vogelstein_cloud_2016,
+@article{vogelsteinCloudGrassrootsProposal2016,
 	title = {To the {Cloud}! {A} {Grassroots} {Proposal} to {Accelerate} {Brain} {Science} {Discovery}},
 	volume = {92},
 	issn = {0896-6273},
@@ -2349,7 +2380,7 @@ First alpha release of the STAMPED principles schema.},
 	pages = {622--627},
 }
 
-@article{eglen_toward_2017,
+@article{eglenStandardPracticesSharing2017,
 	title = {Toward standard practices for sharing computer code and programs in neuroscience},
 	volume = {20},
 	issn = {1097-6256},
@@ -2362,7 +2393,7 @@ First alpha release of the STAMPED principles schema.},
 	pages = {770--773},
 }
 
-@article{eglen_towards_2016,
+@article{eglenStandardPracticesSharing2016,
 	title = {Towards standard practices for sharing computer code and programs in neuroscience},
 	url = {http://biorxiv.org/content/early/2016/03/24/045104},
 	doi = {10.1101/045104},
@@ -2371,7 +2402,7 @@ First alpha release of the STAMPED principles schema.},
 	year = {2016},
 }
 
-@article{halchenko_transmodal_2013,
+@article{halchenkoTransmodalAnalysisNeural2013,
 	title = {Transmodal {Analysis} of {Neural} {Signals}},
 	url = {http://arxiv.org/abs/1307.2150},
 	journal = {ArXiv e-prints},
@@ -2380,14 +2411,14 @@ First alpha release of the STAMPED principles schema.},
 	year = {2013},
 }
 
-@misc{sochat_us-rse_2019,
+@misc{sochatUSRSEStoriesOpen2019,
 	title = {{US}-{RSE} {Stories}: {Open} up, {Neuroscience}! {Here} comes {NeuroDebian}},
 	url = {http://us-rse.org/rse-stories/2019/yaroslav/},
 	author = {Sochat, Vanessa and Halchenko, Yaroslav O.},
 	year = {2019},
 }
 
-@article{botvinik-nezer_variability_2020,
+@article{botvinik-nezerVariabilityAnalysisSingle2020,
 	title = {Variability in the analysis of a single neuroimaging dataset by many teams},
 	volume = {582},
 	issn = {0028-0836, 1476-4687},
@@ -2403,14 +2434,14 @@ First alpha release of the STAMPED principles schema.},
 	pages = {84--88},
 }
 
-@misc{halchenko_variability_2018,
+@misc{halchenkoVariabilityNeuroimagingResults2018,
 	title = {Variability of the {Neuroimaging} {Results} {Across} {OS}, and {How} to {Avoid} it},
 	author = {Halchenko, Yaroslav O. and Ghosh, Satrajit and Poline, Jean-Baptiste and Jarecka, Dorota and Kennedy, David},
 	year = {2018},
 	note = {Published: Talk presented at the annual meeting of the Biological Psychiatry},
 }
 
-@incollection{bickel_wavelab_1995,
+@incollection{buckheitWaveLabReproducibleResearch1995,
 	address = {New York, NY},
 	title = {{WaveLab} and {Reproducible} {Research}},
 	volume = {103},
@@ -2427,14 +2458,14 @@ First alpha release of the STAMPED principles schema.},
 	pages = {55--81},
 }
 
-@misc{hanke_what_2023,
+@misc{hankeWhatDataLadWhat2023,
 	title = {What is {DataLad} and what can it do for you?},
 	url = {https://files.inm7.de/mih/pres/talks/whatisdatalad_2023.html},
 	author = {Hanke, Michael},
 	year = {2023},
 }
 
-@article{manelis_white_2021,
+@article{manelisWhiteMatterAbnormalities2021,
 	title = {White matter abnormalities in adults with bipolar disorder type-{II} and unipolar depression},
 	volume = {11},
 	url = {https://doi.org/10.1038/s41598-021-87069-2},
@@ -2446,7 +2477,24 @@ First alpha release of the STAMPED principles schema.},
 	year = {2021},
 }
 
-@article{manelis_working_2022,
+@article{bechhoferWhyLinkedData2013,
+	title = {Why linked data is not enough for scientists},
+	volume = {29},
+	copyright = {https://www.elsevier.com/tdm/userlicense/1.0/},
+	issn = {0167739X},
+	url = {https://linkinghub.elsevier.com/retrieve/pii/S0167739X11001439},
+	doi = {10.1016/j.future.2011.08.004},
+	language = {en},
+	number = {2},
+	urldate = {2026-08-06},
+	journal = {Future Generation Computer Systems},
+	author = {Bechhofer, Sean and Buchan, Iain and De Roure, David and Missier, Paolo and Ainsworth, John and Bhagat, Jiten and Couch, Philip and Cruickshank, Don and Delderfield, Mark and Dunlop, Ian and Gamble, Matthew and Michaelides, Danius and Owen, Stuart and Newman, David and Sufi, Shoaib and Goble, Carole},
+	month = feb,
+	year = {2013},
+	pages = {599--611},
+}
+
+@article{manelisWorkingMemoryUpdating2022,
 	title = {Working memory updating in individuals with bipolar and unipolar depression: {fMRI} study},
 	volume = {12},
 	url = {https://doi.org/10.1038/s41398-022-02211-6},
@@ -2458,29 +2506,10 @@ First alpha release of the STAMPED principles schema.},
 	year = {2022},
 }
 
-@misc{hanke_yoda_2018,
+@misc{hankeYODAYODAsOrganigram2018,
 	title = {{YODA}: {YODA}’s organigram on data analysis},
 	url = {https://github.com/myyoda/poster/blob/master/ohbm2018.pdf},
 	author = {Hanke, Michael and Visconti di Oleggio Castello, Matteo and Meyer, Kyle and Poldrack, Benjamin and Halchenko, Yaroslav O.},
 	year = {2018},
 	note = {Published: Poster presented at the annual meeting of the Organization for Human Brain Mapping, Singapore},
-}
-
-@article{stewart_software_2010,
-  author = {Stewart, Kate and Odence, Phil and Rockett, Esteban},
-  title = {Software Package Data Exchange ({SPDX}) Specification},
-  journal = {International Free and Open Source Software Law Review},
-  volume = {2},
-  number = {2},
-  pages = {191--196},
-  year = {2010},
-  do = {10.5033/ifosslr.v2i2.45},
-  url = {https://www.ifosslr.org/ifosslr/article/view/45}
-}
-
-@misc{fsfe_reuse_2024,
-  author = {{Free Software Foundation Europe}},
-  title = {{REUSE} Specification, Version 3.3},
-  year = {2024},
-  url = {https://reuse.software/spec-3.3/}
 }


### PR DESCRIPTION
Draft because this is potentially dangerous, our citations MUST be correct. I've done a  first pass review and I think its sane, but theres a lot here and it needs review with fresh eyes. The migration code is fully AI-generated and not carefully reviewed, though I think the verification setup is a pretty decent test.

Also worth discussing if someone can think of a less invasive option. 
 
## Summary

Zotero's BibTeX export changed between 2026-07-30 and 2026-08-06: it now returns each item's stored citation key rather than generating one at export time. Regenerating `references.bib` consequently renames 59 of the 61 keys `main.tex` cites. This moves the manuscript onto the new keys so the bibliography is regenerable again.

I've asked about this in their forum https://forums.zotero.org/discussion/133115/bibtex-export-via-the-web-api-now-returns-stored-citation-keys-instead-of-generated-ones#latest

## Changes

- **`code/migrate-citation-keys.py`** (new) — resolves every citation site to an identity that survives a rename (DOI, else URL, else title), maps old keys to new, rewrites `main.tex`, then verifies every site still resolves to the identity it had before.
- **`references.bib`** — regenerated from the Zotero group library under `datalad run`, so the exact command is recorded in the commit rather than being a hand-run step.
- **`main.tex`** — 82 citation sites rewritten across 51 lines. Keys only: no prose, no reflowing.
- **SPDX and REUSE entries restored** in a separate commit, under a comment block that says they are hand-maintained. See below.

## Verification

- All 61 cited keys resolve.
- All 86 non-exempt citation sites keep their exact DOI/URL identity across the rename. This is deliberately stronger than checking that keys resolve — a citation silently repointed at a *different* record would pass that check and fail this one.
- **The PDF build in CI.**  No files changed!

## The two entries that could not be migrated

`stewart_software_2010` (SPDX) and `fsfe_reuse_2024` (REUSE) are absent from the Zotero library — they were hand-edited into this generated file at some point, so regeneration dropped them and no script can map a key to a record that does not exist. They are restored verbatim under a comment marking them as hand-maintained, and tracked in #197.

<details>
<summary><b>Alternatives considered</b></summary>

1. **Set each cited item's stored key in Zotero to the name `main.tex` already used.** Regeneration output would return to the old names. Rejected: it touches ~60 items in a library other people use, changing what everyone's export produces. The camelCase values are Better BibTeX's, and curators run BBT locally, so hand-set values could be overwritten on a future sync — this fights the tooling rather than going with it.
2. **Stop regenerating; maintain `references.bib` by hand.** Rejected: abandons the generated-file convention and institutionalises exactly the drift that produced #197 and a phantom DOI.
3. **Wait for Zotero upstream before doing anything.** Not treated as an alternative but as a parallel track — asked at https://forums.zotero.org/discussion/133115. Waiting buys nothing on its own: the precedence in the exporter is hardcoded with no export option, so there is no way to ask the API for the old keys in the meantime.

</details>

<details>
<summary><b>Why some keys had several candidates (see #198)</b></summary>

Three cited works have more than one record in the Zotero library, so their identity matched several new keys. Because the candidates share a DOI they denote the same work, and any choice preserves the verification invariant — no citation can land on the wrong paper.

The script therefore takes the first candidate deterministically rather than exposing a flag to pick. For the three cited cases that landed on the most complete record twice, and on the sparser one for Gorgolewski (11 fields vs 15).

The real fix is deduplicating the library, filed as #198. After that dedup and a refetch, whoever picks it up will need to repoint any `\cite` naming a removed record.

</details>

---

*Description drafted by Claude (Claude Code) on behalf of @asmacdo.*
