### PR TITLE
Correct the SPDX DOI and record the YODA poster DOI

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -2461,6 +2461,7 @@ First alpha release of the STAMPED principles schema.},
 @misc{hanke_yoda_2018,
 	title = {{YODA}: {YODA}’s organigram on data analysis},
 	url = {https://github.com/myyoda/poster/blob/master/ohbm2018.pdf},
+	doi = {10.7490/f1000research.1116363.1},
 	author = {Hanke, Michael and Visconti di Oleggio Castello, Matteo and Meyer, Kyle and Poldrack, Benjamin and Halchenko, Yaroslav O.},
 	year = {2018},
 	note = {Published: Poster presented at the annual meeting of the Organization for Human Brain Mapping, Singapore},
@@ -2474,7 +2475,7 @@ First alpha release of the STAMPED principles schema.},
   number = {2},
   pages = {191--196},
   year = {2010},
-  do = {10.5033/ifosslr.v2i2.45},
+  doi = {10.5033/ifosslr.v4i1.45},
   url = {https://www.ifosslr.org/ifosslr/article/view/45}
 }
 


### PR DESCRIPTION
Two cited works were missing from the Zotero group library, and two DOIs were wrong or absent. The library is now fixed; this PR brings `references.bib` into line with it, so the next regeneration reproduces these entries instead of dropping them.

Closes #197

## Review guide

`references.bib` is generated, so the Zotero records are the thing to check. the diff is only what the regeneration would have produced prior to API change (which will be migrated in #199)

- [ ] spdx @CodyCBakerPhD
  - has a different DOI value (the one there didn't work when I looked): was `10.5033/ifosslr.v2i2.45`, now [10.5033/ifosslr.v4i1.45](https://doi.org/10.5033/ifosslr.v4i1.45)
  - zotero record: https://www.zotero.org/groups/6197458/centerforopenneuroscience/search/spdx/titleCreatorYear
- [ ] REUSE @CodyCBakerPhD
  - zotero record: https://www.zotero.org/groups/6197458/centerforopenneuroscience/search/reuse/titleCreatorYear/items/MYDML7E6/item-list
- [ ] yoda poster @yarikoptic
  - DOI added: [10.7490/f1000research.1116363.1](https://doi.org/10.7490/f1000research.1116363.1)
  - zotero record: https://www.zotero.org/groups/6197458/centerforopenneuroscience/search/yoda/titleCreatorYear

<details><summary>Claude extras</summary>

The regeneration in #199 matches old entries to new ones by identity — DOI, else URL, else title — to prove no citation is silently repointed at a different work. With SPDX and YODA identified by URL here but by DOI in Zotero, that match fails and the migration stops.

Landing this first means #199 can drop its `--expect-missing` allowlist and the commit that restored the two hand-maintained entries, so `references.bib` goes back to being purely generated with no hand-edited block.

Checked by fetching the live library and replaying the migration's own identity logic against it: 61 of 61 cited keys map, 0 missing. Without this PR, SPDX and YODA fail to map.

</details>
